### PR TITLE
network: remove navigator.onLine check, use no-cors fetch

### DIFF
--- a/src/webroot/js/network.ts
+++ b/src/webroot/js/network.ts
@@ -52,12 +52,11 @@ async function updateNetworkStatus() {
 }
 
 async function checkOnline(): Promise<boolean> {
-  if (!navigator.onLine) return false;
   for (const endpoint of ONLINE_ENDPOINTS) {
     try {
       const ctrl = new AbortController();
-      const timer = setTimeout(() => ctrl.abort(), 800);
-      await fetch(endpoint, { signal: ctrl.signal });
+      const timer = setTimeout(() => ctrl.abort(), 1500);
+      await fetch(endpoint, { signal: ctrl.signal, mode: 'no-cors' });
       clearTimeout(timer);
       return true;
     } catch { /* try next endpoint */ }


### PR DESCRIPTION
Android WebView in KSU reports navigator.onLine = false even with working connectivity, causing the WebUI to permanently show Offline.

Changes:
- Remove navigator.onLine fast-fail
- mode: no-cors to avoid CORS in KSU WebUI sandbox
- Timeout 800ms to 1500ms for slow connections