### PR TITLE
tools: add Export Logs button

### DIFF
--- a/src/features/export_logs.sh
+++ b/src/features/export_logs.sh
@@ -1,0 +1,49 @@
+#!/system/bin/sh
+set -e
+MODDIR=${0%/*}
+. "$MODDIR/../lib/common.sh"
+
+OUTPUT_DIR="/sdcard/Download"
+OUTPUT_FILE="$OUTPUT_DIR/specter_logs.txt"
+
+log "EXPORT" "Starting log export"
+
+# Ensure output directory exists
+mkdir -p "$OUTPUT_DIR" 2>/dev/null || true
+
+# Start fresh
+: > "$OUTPUT_FILE" || { log "EXPORT" "ERROR: Cannot write to $OUTPUT_FILE"; exit 1; }
+
+log "EXPORT" "Output: $OUTPUT_FILE"
+
+# Helper: append a section (header + file contents + trailing blank line)
+_append_section() {
+  _prefix="$1"
+  _header="$2"
+  _path="$3"
+  echo "$_prefix $_header $_prefix" >> "$OUTPUT_FILE"
+  cat "$_path" >> "$OUTPUT_FILE" 2>/dev/null || true
+  echo "" >> "$OUTPUT_FILE"
+}
+
+# Single glob loop: collect all files from SPECTER_DIR and its log/ subdirectory
+log "EXPORT" "Collecting files from $SPECTER_DIR"
+for _f in "$SPECTER_DIR"/* "$SPECTER_DIR"/log/*; do
+  [ -f "$_f" ] || continue
+  _basename=$(basename "$_f")
+  case "$_basename" in
+    *.log)
+      log "EXPORT" "Adding $_basename (log)"
+      _append_section "===" "$_basename" "$_f"
+      ;;
+    *.json|*.txt|*.pid|*.state|*.flags|*.cfg|*.conf)
+      log "EXPORT" "Adding $_basename (status)"
+      _append_section "---" "$_basename" "$_f"
+      ;;
+  esac
+done
+
+log "EXPORT" "Export complete"
+echo ""
+echo "Logs exported to: $OUTPUT_FILE"
+exit 0

--- a/src/webroot/index.html
+++ b/src/webroot/index.html
@@ -406,6 +406,19 @@
             </div>
           </div>
 
+          <h2 class="list-title" data-i18n="support_section">Support</h2>
+          <div class="list-container">
+            <div class="list-item" data-script="export_logs.sh">
+              <div class="li-icon"><md-icon aria-hidden="true">bug_report</md-icon></div>
+              <div class="list-item-content">
+                <div class="toggle-text" data-i18n="export_logs_title">Export Logs</div>
+                <span class="supporting-text" data-i18n="export_logs_desc">Save all Specter debug logs to /sdcard/Download/</span>
+              </div>
+              <div class="spacer"></div>
+              <md-circular-progress indeterminate class="action-spinner hidden"></md-circular-progress>
+              <md-ripple></md-ripple>
+            </div>
+          </div>
         </section>
 
         <section id="control-page" hidden>

--- a/src/webroot/lang/source/string.json
+++ b/src/webroot/lang/source/string.json
@@ -302,5 +302,8 @@
   "tee_tier_unknown": "Unknown",
   "boot_hash_tee": "BHash (TEE)",
   "boot_hash_prop": "BHash (Prop)",
-  "boot_hash_calc": "BHash (Calc)"
+  "boot_hash_calc": "BHash (Calc)",
+  "export_logs_title": "Export Logs",
+  "export_logs_desc": "Save all Specter debug logs to /sdcard/Download/",
+  "support_section": "Support"
 }


### PR DESCRIPTION
Adds a one-click Export Logs button in the Tools page that collects all Specter debug logs (boot, tee, scheduler, action) and status files into /sdcard/Download/specter_logs.txt for easy retrieval and sharing.