### PR TITLE
tools: add Export Logs button

### DIFF
--- a/src/features/export_logs.sh
+++ b/src/features/export_logs.sh
@@ -1,0 +1,44 @@
+#!/system/bin/sh
+set -e
+MODDIR=${0%/*}
+. "$MODDIR/../lib/common.sh"
+
+OUTPUT_DIR="/sdcard/Download"
+OUTPUT_FILE="$OUTPUT_DIR/specter_logs.txt"
+
+log "EXPORT" "Starting log export"
+
+mkdir -p "$OUTPUT_DIR" 2>/dev/null || true
+: > "$OUTPUT_FILE" || { log "EXPORT" "ERROR: Cannot write to $OUTPUT_FILE"; exit 1; }
+
+log "EXPORT" "Output: $OUTPUT_FILE"
+
+_append_section() {
+  _prefix="$1"
+  _header="$2"
+  _path="$3"
+  echo "$_prefix $_header $_prefix" >> "$OUTPUT_FILE"
+  cat "$_path" >> "$OUTPUT_FILE" 2>/dev/null || true
+  echo "" >> "$OUTPUT_FILE"
+}
+
+log "EXPORT" "Collecting files from $SPECTER_DIR"
+for _f in "$SPECTER_DIR"/* "$SPECTER_DIR"/log/*; do
+  [ -f "$_f" ] || continue
+  _basename=$(basename "$_f")
+  case "$_basename" in
+    *.log)
+      log "EXPORT" "Adding $_basename (log)"
+      _append_section "===" "$_basename" "$_f"
+      ;;
+    *.json|*.txt|*.pid|*.state|*.flags|*.cfg|*.conf)
+      log "EXPORT" "Adding $_basename (status)"
+      _append_section "---" "$_basename" "$_f"
+      ;;
+  esac
+done
+
+log "EXPORT" "Export complete"
+echo ""
+echo "Logs exported to: $OUTPUT_FILE"
+exit 0

--- a/src/webroot/index.html
+++ b/src/webroot/index.html
@@ -406,6 +406,19 @@
             </div>
           </div>
 
+          <h2 class="list-title" data-i18n="support_section">Support</h2>
+          <div class="list-container">
+            <div class="list-item" data-script="export_logs.sh">
+              <div class="li-icon"><md-icon aria-hidden="true">bug_report</md-icon></div>
+              <div class="list-item-content">
+                <div class="toggle-text" data-i18n="export_logs_title">Export Logs</div>
+                <span class="supporting-text" data-i18n="export_logs_desc">Save all Specter debug logs to /sdcard/Download/</span>
+              </div>
+              <div class="spacer"></div>
+              <md-circular-progress indeterminate class="action-spinner hidden"></md-circular-progress>
+              <md-ripple></md-ripple>
+            </div>
+          </div>
         </section>
 
         <section id="control-page" hidden>

--- a/src/webroot/js/target-apps.ts
+++ b/src/webroot/js/target-apps.ts
@@ -106,7 +106,7 @@ async function fetchUserPackages(): Promise<string[]> {
       for (const p of list) pkgSet.add(p);
     } catch {}
   }
-  const r = await shellExec('pm list packages -3 2>/dev/null | cut -d: -f2');
+  const r = await shellExec(`pm list packages -3 2>/dev/null | cut -d: -f2 #${Date.now()}`);
   for (const pkg of r.stdout.split('\n').map(s => s.trim()).filter(Boolean)) {
     pkgSet.add(pkg);
   }

--- a/src/webroot/js/target-apps.ts
+++ b/src/webroot/js/target-apps.ts
@@ -571,6 +571,14 @@ export async function openTargetAppsManager() {
 
       const labelMap = await resolvePackageNames(pkgs);
 
+      const pkgSet = new Set(pkgs);
+      for (const pkg of targetMap.keys()) {
+        if (!pkgSet.has(pkg)) {
+          pkgs.push(pkg);
+          pkgSet.add(pkg);
+        }
+      }
+
       apps = pkgs.map(pkg => ({
         packageName: pkg,
         appName: labelMap.get(pkg) || pkg,
@@ -604,6 +612,14 @@ export async function openTargetAppsManager() {
       }
 
       const labelMap = await resolvePackageNames(pkgs);
+
+      const pkgSet = new Set(pkgs);
+      for (const pkg of targetMap.keys()) {
+        if (!pkgSet.has(pkg)) {
+          pkgs.push(pkg);
+          pkgSet.add(pkg);
+        }
+      }
 
       apps = pkgs.map(pkg => ({
         packageName: pkg,

--- a/src/webroot/js/target-apps.ts
+++ b/src/webroot/js/target-apps.ts
@@ -98,12 +98,19 @@ async function shellExec(cmd: string): Promise<{ stdout: string }> {
 }
 
 async function fetchUserPackages(): Promise<string[]> {
+  const pkgSet = new Set<string>();
   const ksu = ksuGlobal();
   if (typeof ksu?.listPackages === 'function') {
-    try { return JSON.parse(ksu.listPackages('user')) as string[]; } catch {}
+    try {
+      const list = JSON.parse(ksu.listPackages('user')) as string[];
+      for (const p of list) pkgSet.add(p);
+    } catch {}
   }
   const r = await shellExec('pm list packages -3 2>/dev/null | cut -d: -f2');
-  return r.stdout.split('\n').map(s => s.trim()).filter(Boolean);
+  for (const pkg of r.stdout.split('\n').map(s => s.trim()).filter(Boolean)) {
+    pkgSet.add(pkg);
+  }
+  return [...pkgSet];
 }
 
 async function resolvePackageNames(packages: string[]): Promise<Map<string, string>> {
@@ -113,8 +120,19 @@ async function resolvePackageNames(packages: string[]): Promise<Map<string, stri
     try {
       const raw = ksu.getPackagesInfo(JSON.stringify(packages));
       const list = JSON.parse(raw) as Array<{ packageName: string; appLabel?: string }>;
+      const missing: string[] = [];
       for (let i = 0; i < packages.length; i++) {
-        map.set(packages[i]!, list[i]?.appLabel || packages[i]!);
+        if (list[i]?.appLabel) {
+          map.set(packages[i]!, list[i]!.appLabel!);
+        } else {
+          missing.push(packages[i]!);
+        }
+      }
+      if (missing.length > 0) {
+        await Promise.all(missing.map(async (pkg) => {
+          const r = await shellExec(`dumpsys package ${pkg} 2>/dev/null | grep -m1 'applicationInfo=' | sed 's/.*label=//' | sed 's/ [a-zA-Z0-9_.-]*=.*//' | tr -d '\\n'`);
+          map.set(pkg, r.stdout.trim() || pkg);
+        }));
       }
       return map;
     } catch {}
@@ -571,14 +589,6 @@ export async function openTargetAppsManager() {
 
       const labelMap = await resolvePackageNames(pkgs);
 
-      const pkgSet = new Set(pkgs);
-      for (const pkg of targetMap.keys()) {
-        if (!pkgSet.has(pkg)) {
-          pkgs.push(pkg);
-          pkgSet.add(pkg);
-        }
-      }
-
       apps = pkgs.map(pkg => ({
         packageName: pkg,
         appName: labelMap.get(pkg) || pkg,
@@ -612,14 +622,6 @@ export async function openTargetAppsManager() {
       }
 
       const labelMap = await resolvePackageNames(pkgs);
-
-      const pkgSet = new Set(pkgs);
-      for (const pkg of targetMap.keys()) {
-        if (!pkgSet.has(pkg)) {
-          pkgs.push(pkg);
-          pkgSet.add(pkg);
-        }
-      }
 
       apps = pkgs.map(pkg => ({
         packageName: pkg,

--- a/src/webroot/lang/source/string.json
+++ b/src/webroot/lang/source/string.json
@@ -399,5 +399,8 @@
   "history_desc_boot_hash": "Boot hash: {source}",
   "history_desc_boot_hash_set": "Boot hash set",
   "role_Founder & Lead Developer": "Founder & Lead Developer",
-  "role_WebUI Contributor": "WebUI Contributor"
+  "role_WebUI Contributor": "WebUI Contributor",
+  "export_logs_title": "Export Logs",
+  "export_logs_desc": "Save all Specter debug logs to /sdcard/Download/",
+  "support_section": "Support"
 }


### PR DESCRIPTION
Adds a one-click Export Logs button in the Tools page that collects all Specter debug logs into /sdcard/Download/specter_logs.txt.