### PR TITLE
feat(omk): add OhMyKeymint support and update backend contributors

### DIFF
--- a/src/action.sh
+++ b/src/action.sh
@@ -101,6 +101,7 @@ _first_boot=0
 
   run_device_info "$MODDIR"
   sh "$MODDIR/features/keybox_info.sh" >/dev/null 2>&1 || true
+  sh "$MODDIR/features/keystore_info.sh" >/dev/null 2>&1 || true
 
   [ -f "$MODDIR/module.prop.bak" ] && cp "$MODDIR/module.prop.bak" "$MODDIR/module.prop"
   . "$MODDIR/lib/desc.sh"

--- a/src/customize.sh
+++ b/src/customize.sh
@@ -35,6 +35,14 @@ else
   ui_print "- Tricky Store: none"
 fi
 
+# OhMyKeymint version
+_omk_name=$(_omk_prop)
+if [ -n "$_omk_name" ]; then
+  ui_print "- $_omk_name"
+else
+  ui_print "- OhMyKeymint: none"
+fi
+
 # PIF version
 _pif_name=$(_pif_prop)
 if [ -n "$_pif_name" ]; then
@@ -55,16 +63,20 @@ ui_print ""
 
 unset _zygisk_name
 
-# Install missing: TEESimulator-RS
-if [ -z "$_ts_name" ]; then
+# Install missing: TEESimulator-RS (skip entirely if OMK is present — OMK is
+# its own keystore implementation and doesn't need/use Tricky Store or a
+# TEE simulator fork)
+if [ -z "$_ts_name" ] && [ -z "$_omk_name" ]; then
   ui_print "- Installing TEESimulator-RS.."
   if install_module_from_github "Enginex0/TEESimulator-RS" "TEESimulator-RS"; then
     ui_print "- TEESimulator-RS installed"
   else
     ui_print "- TEESimulator-RS not available"
   fi
+elif [ -n "$_omk_name" ]; then
+  ui_print "- OhMyKeymint detected, skipping TEESimulator-RS"
 fi
-unset _ts_name
+unset _ts_name _omk_name
 
 # Mark first-boot setup as pending (runs once after reboot in service.sh)
 mkdir -p "$SPECTER_DIR"

--- a/src/features/auto_target.sh
+++ b/src/features/auto_target.sh
@@ -4,6 +4,8 @@ MODDIR=${0%/*}
 . "$MODDIR/../lib/common.sh"
 . "$MODDIR/../lib/constants.sh"
 
+detect_keystore_manager
+
 BLACKLIST="$SPECTER_DIR/blacklist.txt"
 BLACKLIST_ENABLED="$SPECTER_DIR/blacklist_enabled"
 KNOWN_PKGS="$SPECTER_DIR/auto_known_packages.txt"
@@ -13,11 +15,15 @@ _feature_should_run "target" || { log_d "AUTO_TARGET" "target disabled or claime
 
 log_i "AUTO_TARGET" "Scanning for new packages"
 
-[ -f "$TARGET_TXT" ] || { log_w "AUTO_TARGET" "target.txt missing, skipping"; exit 0; }
+ksm_available || { log_d "AUTO_TARGET" "no keystore manager, skipping"; exit 0; }
+[ -f "$KSM_TARGETS" ] || { log_w "AUTO_TARGET" "target list missing, skipping"; exit 0; }
 
 pkgs=$(pm list packages -3 2>/dev/null) || { log_e "AUTO_TARGET" "pm list packages failed"; exit 1; }
 echo "$pkgs" | cut -d ":" -f 2 | sort -u > "$TEMP_LIST"
 [ ! -s "$TEMP_LIST" ] && { rm -f "$TEMP_LIST"; exit 0; }
+
+_EXISTING="$SPECTER_DIR/.auto_target_existing.$$"
+ksm_read_targets > "$_EXISTING" 2>/dev/null || : > "$_EXISTING"
 
 _known=""
 [ -f "$KNOWN_PKGS" ] && _known=$(cat "$KNOWN_PKGS")
@@ -25,7 +31,7 @@ _known=""
 _new_pkgs=""
 while IFS= read -r _pkg; do
   [ -z "$_pkg" ] && continue
-    if ! echo "$_known" | grep -Fxq "$_pkg" 2>/dev/null && ! grep -Fxq "$_pkg" "$TARGET_TXT" 2>/dev/null; then
+    if ! echo "$_known" | grep -Fxq "$_pkg" 2>/dev/null && ! grep -Fxq "$_pkg" "$_EXISTING" 2>/dev/null; then
     if [ -f "$BLACKLIST_ENABLED" ] && [ -s "$BLACKLIST" ]; then
       if grep -Fxq "$_pkg" "$BLACKLIST" 2>/dev/null; then
         continue
@@ -35,6 +41,9 @@ while IFS= read -r _pkg; do
 "
   fi
 done < "$TEMP_LIST"
+
+_STAGING="$SPECTER_DIR/.auto_target_staging.$$"
+ksm_read_targets_raw > "$_STAGING" 2>/dev/null || : > "$_STAGING"
 
 if [ -n "$_new_pkgs" ]; then
   _default_mode=$(cfg_get target_default_mode "bare")
@@ -46,7 +55,7 @@ if [ -n "$_new_pkgs" ]; then
   _added=0
   while IFS= read -r _pkg; do
     [ -z "$_pkg" ] && continue
-    echo "${_pkg}${_suffix}" >> "$TARGET_TXT"
+    echo "${_pkg}${_suffix}" >> "$_STAGING"
     _added=$((_added + 1))
   done <<EOF
 $_new_pkgs
@@ -59,7 +68,8 @@ fi
 _installed_list=$(pm list packages -3 2>/dev/null | cut -d: -f2 | sort -u)
 _bl_set=""
 [ -f "$BLACKLIST_ENABLED" ] && [ -s "$BLACKLIST" ] && _bl_set=$(cat "$BLACKLIST")
-_TMP_CLEAN="${TARGET_TXT}.clean.$$"
+_TMP_CLEAN="$SPECTER_DIR/.auto_target_clean.$$"
+: > "$_TMP_CLEAN"
 
 _cleaned=0
 while IFS= read -r _line || [ -n "$_line" ]; do
@@ -81,15 +91,14 @@ while IFS= read -r _line || [ -n "$_line" ]; do
   else
     _cleaned=$((_cleaned + 1))
   fi
-done < "$TARGET_TXT"
+done < "$_STAGING"
 
-if [ -f "$_TMP_CLEAN" ]; then
-  mv -f "$_TMP_CLEAN" "$TARGET_TXT"
-  [ "$_cleaned" -gt 0 ] && log_i "AUTO_TARGET" "Removed $_cleaned stale/blacklisted entry(s)"
-fi
-unset _installed_list _bl_set _TMP_CLEAN _cleaned _fixed _keep _base
+ksm_commit_targets "$_TMP_CLEAN"
+[ "$_cleaned" -gt 0 ] && log_i "AUTO_TARGET" "Removed $_cleaned stale/blacklisted entry(s)"
+
+unset _installed_list _bl_set _cleaned _fixed _keep _base
 
 cp "$TEMP_LIST" "$KNOWN_PKGS" 2>/dev/null || true
-rm -f "$TEMP_LIST"
+rm -f "$TEMP_LIST" "$_EXISTING" "$_STAGING"
 log_i "AUTO_TARGET" "Auto-target scan complete"
 exit 0

--- a/src/features/first_boot_setup.sh
+++ b/src/features/first_boot_setup.sh
@@ -8,27 +8,39 @@ log_i "FIRST_BOOT" "Starting first-boot setup"
 
 ensure_dir "$BACKUP_DIR"
 
-log_i "FIRST_BOOT" "Backing up existing Tricky Store files"
+detect_keystore_manager
 
-if [ -f "$TARGET_FILE" ]; then
-  cp "$TARGET_FILE" "$BACKUP_DIR/keybox.xml.bak"
-  log_d "FIRST_BOOT" "Backed up $TARGET_FILE"
+log_i "FIRST_BOOT" "Backing up existing $KSM_NAME files"
+
+if [ -f "$KSM_KEYBOX" ]; then
+  cp "$KSM_KEYBOX" "$BACKUP_DIR/keybox.xml.bak"
+  log_d "FIRST_BOOT" "Backed up $KSM_KEYBOX"
 fi
 
-if [ -f "$TARGET_TXT" ]; then
-  cp "$TARGET_TXT" "$BACKUP_DIR/target.txt.bak"
-  log_d "FIRST_BOOT" "Backed up $TARGET_TXT"
-fi
-
-if [ -f "$LOCKED_FILE" ]; then
-  cp "$LOCKED_FILE" "$BACKUP_DIR/locked.xml.bak"
-  log_d "FIRST_BOOT" "Backed up $LOCKED_FILE"
-fi
-
-if [ -f "$SECURITY_PATCH_FILE" ]; then
-  cp "$SECURITY_PATCH_FILE" "$BACKUP_DIR/security_patch.txt.bak"
-  log_d "FIRST_BOOT" "Backed up $SECURITY_PATCH_FILE"
-fi
+case "$KSM_FORMAT" in
+  toml)
+    # injector.toml/config.toml carry OMK settings beyond what Specter
+    # manages, so back up only the values Specter owns, not the whole file.
+    ksm_read_targets > "$BACKUP_DIR/targets.list.bak" 2>/dev/null
+    _fbs_patch=$(sh "$MODDIR/security_patch.sh" --get 2>/dev/null) || _fbs_patch=""
+    [ -n "$_fbs_patch" ] && printf '%s\n' "$_fbs_patch" > "$BACKUP_DIR/security_patch.value.bak"
+    unset _fbs_patch
+    ;;
+  *)
+    if [ -f "$KSM_TARGETS" ]; then
+      cp "$KSM_TARGETS" "$BACKUP_DIR/target.txt.bak"
+      log_d "FIRST_BOOT" "Backed up $KSM_TARGETS"
+    fi
+    if [ -f "$KSM_LOCKED" ]; then
+      cp "$KSM_LOCKED" "$BACKUP_DIR/locked.xml.bak"
+      log_d "FIRST_BOOT" "Backed up $KSM_LOCKED"
+    fi
+    if [ -f "$KSM_SECURITY" ]; then
+      cp "$KSM_SECURITY" "$BACKUP_DIR/security_patch.txt.bak"
+      log_d "FIRST_BOOT" "Backed up $KSM_SECURITY"
+    fi
+    ;;
+esac
 
 log_i "FIRST_BOOT" "Waiting for network..."
 for _sec in 1 2 3 4 5 6 7 8 9 10; do check_network 2>/dev/null && break; sleep 1; done

--- a/src/features/keybox.sh
+++ b/src/features/keybox.sh
@@ -8,7 +8,8 @@ log_d "KEYBOX" "Starting keybox fetch/install"
 
 check_network || { log_e "KEYBOX" "No internet connection"; exit 1; }
 
-[ -d "$TRICKY_DIR" ] || die "Tricky Store data directory not found"
+detect_keystore_manager
+ksm_available || die "No keystore manager (Tricky Store / OhMyKeymint) data directory found"
 
 DECODE_FILE="/data/local/tmp/keybox_decode.$$"
 TEMP_FILE="/data/local/tmp/keybox.tmp.$$"
@@ -28,7 +29,7 @@ if [ -n "$_custom_type" ] && [ -n "$_custom_value" ]; then
   case "$_custom_type" in
     file|path)
       if [ -f "$_custom_value" ]; then
-        cp "$_custom_value" "$TARGET_FILE" || die "Failed to copy custom keybox"
+        ksm_install_keybox "$_custom_value" copy || die "Failed to copy custom keybox"
         log_i "KEYBOX" "Custom keybox installed from $_custom_value"
         _clear_custom
         exit 0
@@ -45,7 +46,7 @@ download "$_custom_value" "$TEMP_FILE" || {
   exit 1
 }
 if decode_keybox_blob "$TEMP_FILE" "$DECODE_FILE" 2>/dev/null && [ -s "$DECODE_FILE" ]; then
-        mv "$DECODE_FILE" "$TARGET_FILE" || die "Failed to move decoded keybox"
+        ksm_install_keybox "$DECODE_FILE" || die "Failed to move decoded keybox"
         log_i "KEYBOX" "Custom keybox installed from URL"
         _clear_custom
         exit 0
@@ -219,12 +220,12 @@ _clear_keybox_id() {
 if _is_teesimulator; then
     _install_teesimulator
     _clear_keybox_id
-    cp "$DECODE_FILE" "$TARGET_FILE" 2>/dev/null || true
+    ksm_install_keybox "$DECODE_FILE" copy
     log_i "KEYBOX" "Keybox install complete"
     exit 0
 fi
 
-mv "$DECODE_FILE" "$TARGET_FILE" || die "Failed to move decoded keybox to $TARGET_FILE"
+ksm_install_keybox "$DECODE_FILE" || die "Failed to move decoded keybox to $KSM_KEYBOX"
 _clear_keybox_id
 log_i "KEYBOX" "Keybox installed successfully"
 log_i "KEYBOX" "Keybox install complete"

--- a/src/features/keybox_info.sh
+++ b/src/features/keybox_info.sh
@@ -6,7 +6,8 @@ MODDIR=${0%/*}
 
 log_i "KEYBOX_INFO" "Starting keybox info check"
 
-KEYBOX_FILE="$TRICKY_DIR/keybox.xml"
+detect_keystore_manager
+KEYBOX_FILE="$KSM_KEYBOX"
 INFO_PATH="$MODDIR/../webroot/json/keybox_info.json"
 
 ensure_dir "$(dirname "$INFO_PATH")"

--- a/src/features/keystore_info.sh
+++ b/src/features/keystore_info.sh
@@ -1,0 +1,24 @@
+#!/system/bin/sh
+set -e
+MODDIR=${0%/*}
+. "$MODDIR/../lib/common.sh"
+. "$MODDIR/../lib/constants.sh"
+
+detect_keystore_manager
+
+INFO_PATH="$MODDIR/../webroot/json/keystore_manager.json"
+ensure_dir "$(dirname "$INFO_PATH")"
+
+cat <<EOF > "$INFO_PATH"
+{
+  "id": "$KSM",
+  "name": "$(_escape_json "$KSM_NAME")",
+  "format": "$(_escape_json "$KSM_FORMAT")",
+  "dir": "$(_escape_json "$KSM_DIR")",
+  "targets": "$(_escape_json "$KSM_TARGETS")",
+  "security": "$(_escape_json "$KSM_SECURITY")"
+}
+EOF
+
+log_i "KEYSTORE_INFO" "Active manager: ${KSM_NAME:-none}"
+exit 0

--- a/src/features/restore_backups.sh
+++ b/src/features/restore_backups.sh
@@ -12,31 +12,49 @@ if [ ! -d "$BACKUP_DIR" ]; then
   exit 1
 fi
 
+detect_keystore_manager
+
 _restored=0
 
-if [ -f "$BACKUP_DIR/keybox.xml.bak" ]; then
-  cp "$BACKUP_DIR/keybox.xml.bak" "$TARGET_FILE"
+if [ -f "$BACKUP_DIR/keybox.xml.bak" ] && [ -n "$KSM_KEYBOX" ]; then
+  cp "$BACKUP_DIR/keybox.xml.bak" "$KSM_KEYBOX"
   log_i "RESTORE" "Restored keybox.xml"
   _restored=$((_restored + 1))
 fi
 
-if [ -f "$BACKUP_DIR/target.txt.bak" ]; then
-  cp "$BACKUP_DIR/target.txt.bak" "$TARGET_TXT"
-  log_i "RESTORE" "Restored target.txt"
-  _restored=$((_restored + 1))
-fi
-
-if [ -f "$BACKUP_DIR/locked.xml.bak" ]; then
-  cp "$BACKUP_DIR/locked.xml.bak" "$LOCKED_FILE"
-  log_i "RESTORE" "Restored locked.xml"
-  _restored=$((_restored + 1))
-fi
-
-if [ -f "$BACKUP_DIR/security_patch.txt.bak" ]; then
-  cp "$BACKUP_DIR/security_patch.txt.bak" "$SECURITY_PATCH_FILE"
-  log_i "RESTORE" "Restored security_patch.txt"
-  _restored=$((_restored + 1))
-fi
+case "$KSM_FORMAT" in
+  toml)
+    if [ -f "$BACKUP_DIR/targets.list.bak" ]; then
+      _rb_tmp="$SPECTER_DIR/.restore_targets.$$"
+      cp "$BACKUP_DIR/targets.list.bak" "$_rb_tmp"
+      ksm_commit_targets "$_rb_tmp"
+      log_i "RESTORE" "Restored app target list"
+      _restored=$((_restored + 1))
+    fi
+    if [ -f "$BACKUP_DIR/security_patch.value.bak" ]; then
+      ksm_set_security_patch "$(cat "$BACKUP_DIR/security_patch.value.bak")"
+      log_i "RESTORE" "Restored security patch"
+      _restored=$((_restored + 1))
+    fi
+    ;;
+  *)
+    if [ -f "$BACKUP_DIR/target.txt.bak" ] && [ -n "$KSM_TARGETS" ]; then
+      cp "$BACKUP_DIR/target.txt.bak" "$KSM_TARGETS"
+      log_i "RESTORE" "Restored target.txt"
+      _restored=$((_restored + 1))
+    fi
+    if [ -f "$BACKUP_DIR/locked.xml.bak" ] && [ -n "$KSM_LOCKED" ]; then
+      cp "$BACKUP_DIR/locked.xml.bak" "$KSM_LOCKED"
+      log_i "RESTORE" "Restored locked.xml"
+      _restored=$((_restored + 1))
+    fi
+    if [ -f "$BACKUP_DIR/security_patch.txt.bak" ] && [ -n "$KSM_SECURITY" ]; then
+      cp "$BACKUP_DIR/security_patch.txt.bak" "$KSM_SECURITY"
+      log_i "RESTORE" "Restored security_patch.txt"
+      _restored=$((_restored + 1))
+    fi
+    ;;
+esac
 
 if [ "$_restored" -eq 0 ]; then
   log_w "RESTORE" "No backup files found"

--- a/src/features/security_patch.sh
+++ b/src/features/security_patch.sh
@@ -4,6 +4,8 @@ MODDIR=${0%/*}
 . "$MODDIR/../lib/common.sh"
 . "$MODDIR/../lib/constants.sh"
 
+detect_keystore_manager
+
 case "${1:-}" in
   --fetch)
     _sp=$(download "https://source.android.com/docs/security/bulletin/pixel" 2>/dev/null |
@@ -15,7 +17,27 @@ case "${1:-}" in
     fi
     exit 1
     ;;
+  --get)
+    [ -f "$KSM_SECURITY" ] || exit 1
+    case "$KSM_FORMAT" in
+      toml) grep -E '^[ ]*security_patch[ ]*=' "$KSM_SECURITY" 2>/dev/null | head -1 | sed 's/.*=[ ]*"\([^"]*\)".*/\1/' ;;
+      *) grep -E '^(boot|all)=' "$KSM_SECURITY" 2>/dev/null | head -1 | cut -d= -f2 ;;
+    esac
+    exit 0
+    ;;
+  --set)
+    case "${2:-}" in
+      [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+      *) die "security_patch.sh --set requires a YYYY-MM-DD date" ;;
+    esac
+    ksm_available || die "No keystore manager (Tricky Store / OhMyKeymint) data directory found"
+    ksm_set_security_patch "$2" || die "Failed to write $KSM_SECURITY"
+    log_i "SECURITY_PATCH" "Security patch manually set to $2"
+    exit 0
+    ;;
 esac
+
+ksm_available || die "No keystore manager (Tricky Store / OhMyKeymint) data directory found"
 
 # Try to fetch the real security patch date from source.android.com first.
 # Network may not be available yet at boot, so fall back to date computation.
@@ -33,8 +55,6 @@ else
 fi
 unset _patch
 
-{
-  echo "all=${patch_date}"
-} > "$SECURITY_PATCH_FILE" || die "Failed to write $SECURITY_PATCH_FILE"
+ksm_set_security_patch "$patch_date" || die "Failed to write $KSM_SECURITY"
 log_i "SECURITY_PATCH" "The security patch is written"
 exit 0

--- a/src/features/target.sh
+++ b/src/features/target.sh
@@ -7,24 +7,39 @@ MODDIR=${0%/*}
 
 log_d "TARGET" "Starting target management"
 
-[ -d "$TRICKY_DIR" ] || die "Tricky Store data directory not found"
+detect_keystore_manager
+ksm_available || die "No keystore manager (Tricky Store / OhMyKeymint) data directory found"
+
+case "${1:-}" in
+  --list)
+    ksm_read_targets
+    exit 0
+    ;;
+  --set)
+    [ -n "${2:-}" ] && [ -f "$2" ] || die "target.sh --set requires an existing file argument"
+    ksm_commit_targets "$2"
+    log_i "TARGET" "Committed target list from $2"
+    exit 0
+    ;;
+esac
 
 MODULE_ROOT="${MODDIR%/features}"
 TEMP_PKGS="$MODULE_ROOT/pkgs.txt"
-_TMP_TARGET="${TARGET_TXT}.new.$$"
+_TMP_TARGET="$SPECTER_DIR/.target_new.$$"
 
 _read_tee_status
 _ensure_blacklist
 _parse_customize
 
 _ensure_target_txt() {
-  [ -f "$TARGET_TXT" ] && [ -s "$TARGET_TXT" ] && return 0
-  log_w "TARGET" "target.txt missing or empty, creating default"
-  mkdir -p "$(dirname "$TARGET_TXT")" 2>/dev/null || true
+  [ -n "$(ksm_read_targets)" ] && return 0
+  log_w "TARGET" "target list missing or empty, creating default"
+  _et_tmp="$SPECTER_DIR/.target_seed.$$"
   for _entry in $FIXED_TARGETS; do
     echo "$_entry"
-  done > "$TARGET_TXT"
-  unset _entry
+  done > "$_et_tmp"
+  ksm_commit_targets "$_et_tmp"
+  unset _entry _et_tmp
 }
 
 _ensure_target_txt
@@ -121,12 +136,10 @@ case "${1}" in
 
     sort -u "$_TMP_TARGET" -o "$_TMP_TARGET"
 
-    rm -f "${TARGET_TXT}.bak"
-    [ -f "$TARGET_TXT" ] && cp "$TARGET_TXT" "${TARGET_TXT}.bak"
-    mv -f "$_TMP_TARGET" "$TARGET_TXT"
+    ksm_commit_targets "$_TMP_TARGET"
 
-    _count=$(wc -l < "$TARGET_TXT")
-    log_i "TARGET" "Wrote $_count entries to target.txt"
+    _count=$(ksm_read_targets | wc -l)
+    log_i "TARGET" "Wrote $_count entries to target list"
     ;;
 esac
 

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -17,6 +17,7 @@ fi
 . "$_root/lib/detect.sh"
 . "$_root/lib/props.sh"
 . "$_root/lib/keybox.sh"
+. "$_root/lib/keystore.sh"
 . "$_root/lib/conflicts.sh"
 
 : "${CONFIG_DIR:="$SPECTER_DIR/config"}"

--- a/src/lib/constants.sh
+++ b/src/lib/constants.sh
@@ -31,6 +31,14 @@ FALLBACK_KEYBOXES="Yuri/8"
 : "${GMS_PROPS_FILE:=/data/system/gms_certified_props.json}"
 : "${BACKUP_DIR:=$SPECTER_DIR/backup}"
 
+# -- OhMyKeymint (OMK) paths (defaults, overridable by env) --
+: "${OMK_MODULE:=$MODULES_BASE/OhMyKeymint}"
+: "${OMK_DIR:=/data/misc/keystore/omk}"
+: "${OMK_KEYBOX:=$OMK_DIR/keybox.xml}"
+: "${OMK_INJECTOR:=$OMK_DIR/injector.toml}"
+: "${OMK_CONFIG:=$OMK_DIR/config.toml}"
+: "${OMK_RESTART_DIR:=/data/adb/omk}"
+
 # -- Package lists --
 GMS_APPS="com.android.vending com.google.android.gsf com.google.android.gms com.google.android.contactkeys com.google.android.ims com.google.android.safetycore com.google.android.apps.walletnfcrel com.google.android.apps.nbu.paisa.user"
 FIXED_TARGETS="android $GMS_APPS"

--- a/src/lib/desc.sh
+++ b/src/lib/desc.sh
@@ -3,10 +3,11 @@
 # Provides refresh_module_description() for boot-time and on-demand use.
 
 refresh_module_description() {
+  detect_keystore_manager
   _problems=""
 
-  if [ ! -d "$MODULES_BASE/tricky_store" ] && [ ! -d "${MODULES_BASE}_update/tricky_store" ]; then
-    _problems="🚨 Tricky Store not installed"
+  if [ "$KSM" = "none" ]; then
+    _problems="🚨 No keystore manager installed"
   fi
 
   _cf=""
@@ -30,11 +31,14 @@ refresh_module_description() {
     [ -z "$_kb_src" ] && _kb_src=$(cfg_get 'keybox_provider' '')
     [ -z "$_kb_src" ] && [ "$(cfg_get 'keybox_private' 'false')" = "true" ] && _kb_src="Private"
 
-    _apps=$(wc -l < "$TARGET_TXT" 2>/dev/null || echo 0)
-    _patch=$(grep -E '^(boot|all)=' "$SECURITY_PATCH_FILE" 2>/dev/null | cut -d= -f2) || true
+    _apps=$(ksm_read_targets 2>/dev/null | wc -l)
+    case "$KSM_FORMAT" in
+      toml) _patch=$(grep -E '^[ ]*security_patch[ ]*=' "$KSM_SECURITY" 2>/dev/null | head -1 | sed 's/.*=[ ]*"\([^"]*\)".*/\1/') ;;
+      *) _patch=$(grep -E '^(boot|all)=' "$KSM_SECURITY" 2>/dev/null | cut -d= -f2) ;;
+    esac
     [ -z "$_patch" ] && _patch="-"
 
-    if [ -f "$TARGET_FILE" ] || [ -f "$LOCKED_FILE" ]; then
+    if [ -f "$KSM_KEYBOX" ] || [ -f "$KSM_LOCKED" ]; then
       _title="$_kb_src${_kb_ver:+ $_kb_ver}"
       if [ -n "$_kb_rev" ]; then
         _new_desc="🔑 $_title · ❌ | $_apps apps | 🛡️ $_patch"

--- a/src/lib/detect.sh
+++ b/src/lib/detect.sh
@@ -60,6 +60,26 @@ _ts_prop() {
   echo ""
 }
 
+# Case-insensitive scan: OMK's installed folder name isn't guaranteed to be
+# exactly "OhMyKeymint" across forks/manual installs.
+_omk_prop() {
+  for _omk_base in "$MODULES_BASE" "${MODULES_BASE}_update"; do
+    [ -d "$_omk_base" ] || continue
+    for _omk_dir in "$_omk_base"/*; do
+      [ -f "$_omk_dir/module.prop" ] || continue
+      case "$(basename "$_omk_dir")" in
+        [Oo]h[Mm]y[Kk]eymint|omk|OMK)
+          grep "^name=" "$_omk_dir/module.prop" 2>/dev/null | cut -d= -f2
+          return 0
+          ;;
+      esac
+    done
+  done
+  [ -f "$OMK_MODULE/module.prop" ] && { grep "^name=" "$OMK_MODULE/module.prop" 2>/dev/null | cut -d= -f2; return 0; }
+  [ -d "$OMK_DIR" ] && { echo "OhMyKeymint"; return 0; }
+  echo ""
+}
+
 _is_teesimulator() {
   case "$(_ts_prop)" in
     *TEESimulator*) return 0 ;;

--- a/src/lib/keystore.sh
+++ b/src/lib/keystore.sh
@@ -1,0 +1,312 @@
+# shellcheck shell=sh
+# Keystore-manager abstraction: makes the rest of the codebase agnostic to
+# whether Tricky Store or OhMyKeymint is the active spoofer backend.
+#
+# Callers must invoke detect_keystore_manager() after sourcing common.sh and
+# before touching any KSM_* variable — detection depends on cfg_get, which
+# needs CONFIG_DIR resolved, and results are not cached across processes
+# (feature scripts run from the WebUI as fresh `sh` invocations).
+
+detect_keystore_manager() {
+  _dkm_override=$(cfg_get keystore_manager auto 2>/dev/null)
+  case "$_dkm_override" in
+    trickystore) KSM=trickystore ;;
+    omk) KSM=omk ;;
+    *)
+      if [ -n "$(_ts_prop)" ]; then
+        KSM=trickystore
+      elif [ -n "$(_omk_prop)" ]; then
+        KSM=omk
+      else
+        KSM=none
+      fi
+      ;;
+  esac
+
+  case "$KSM" in
+    trickystore)
+      KSM_NAME="Tricky Store"
+      KSM_DIR="$TRICKY_DIR"
+      KSM_KEYBOX="$TARGET_FILE"
+      KSM_TARGETS="$TARGET_TXT"
+      KSM_SECURITY="$SECURITY_PATCH_FILE"
+      KSM_LOCKED="$LOCKED_FILE"
+      KSM_FORMAT="txt"
+      ;;
+    omk)
+      KSM_NAME="OhMyKeymint"
+      KSM_DIR="$OMK_DIR"
+      KSM_KEYBOX="$OMK_KEYBOX"
+      KSM_TARGETS="$OMK_INJECTOR"
+      KSM_SECURITY="$OMK_CONFIG"
+      KSM_LOCKED=""
+      KSM_FORMAT="toml"
+      ;;
+    *)
+      KSM_NAME=""
+      KSM_DIR=""
+      KSM_KEYBOX=""
+      KSM_TARGETS=""
+      KSM_SECURITY=""
+      KSM_LOCKED=""
+      KSM_FORMAT=""
+      ;;
+  esac
+
+  export KSM KSM_NAME KSM_DIR KSM_KEYBOX KSM_TARGETS KSM_SECURITY KSM_LOCKED KSM_FORMAT
+  unset _dkm_override
+}
+
+ksm_available() {
+  [ "$KSM" != "none" ] && [ -n "$KSM_DIR" ] && [ -d "$KSM_DIR" ]
+}
+
+# Triggers the active manager to pick up config changes. Tricky Store
+# watches its files directly (no-op here); OMK only reloads on these touches.
+# Touch all three triggers so both the keymint and injector daemons restart
+# regardless of which one is watching which file.
+ksm_reload() {
+  [ "$KSM" = "omk" ] || return 0
+  mkdir -p "$OMK_RESTART_DIR" 2>/dev/null || true
+  touch "$OMK_RESTART_DIR/restart.keymint" 2>/dev/null
+  touch "$OMK_RESTART_DIR/restart.injector" 2>/dev/null
+  touch "$OMK_RESTART_DIR/restart.all" 2>/dev/null
+}
+
+# OMK's keymint/injector processes drop to uid 1017 (AID_KEYSTORE) and read
+# their files at mode 0600, so anything we write into the OMK data dir must be
+# owned by 1017 with a keystore-readable context — a plain mv/cp from
+# /data/local/tmp leaves it root-owned and unreadable to the daemon. No-op for
+# Tricky Store, whose files just live under /data/adb. Dirs pass mode 0770.
+ksm_secure() {
+  [ "$KSM" = "omk" ] || return 0
+  _kse_path="$1" _kse_mode="${2:-0600}"
+  [ -e "$_kse_path" ] || { unset _kse_path _kse_mode; return 0; }
+  chown 1017:1017 "$_kse_path" 2>/dev/null || true
+  chmod "$_kse_mode" "$_kse_path" 2>/dev/null || true
+  chcon u:object_r:keystore_data_file:s0 "$_kse_path" 2>/dev/null \
+    || restorecon "$_kse_path" 2>/dev/null || true
+  unset _kse_path _kse_mode
+}
+
+_ksm_strip_suffix() {
+  _kss_line="$1"
+  case "$_kss_line" in *!) _kss_line=${_kss_line%!} ;; *\?) _kss_line=${_kss_line%\?} ;; esac
+  printf '%s' "$_kss_line"
+  unset _kss_line
+}
+
+# Prints the active target list as bare packages, one per line, regardless
+# of backend format.
+ksm_read_targets() {
+  [ -f "$KSM_TARGETS" ] || return 0
+  case "$KSM_FORMAT" in
+    toml)
+      _toml_read_scoop "$KSM_TARGETS"
+      ;;
+    *)
+      while IFS= read -r _krt_line || [ -n "$_krt_line" ]; do
+        [ -z "$_krt_line" ] && continue
+        case "$_krt_line" in \[*\]) continue ;; esac
+        _krt_base=$(_ksm_strip_suffix "$_krt_line")
+        [ -n "$_krt_base" ] && printf '%s\n' "$_krt_base"
+      done < "$KSM_TARGETS"
+      unset _krt_line _krt_base
+      ;;
+  esac
+}
+
+# Raw seed for building a new staging file: preserves the native file's
+# lines (including !/? suffixes and any [section] header lines) for txt
+# backends; identical to ksm_read_targets for toml backends, which have no
+# such lines to preserve.
+ksm_read_targets_raw() {
+  case "$KSM_FORMAT" in
+    toml) ksm_read_targets ;;
+    *) [ -f "$KSM_TARGETS" ] && cat "$KSM_TARGETS" ;;
+  esac
+}
+
+# Commits a Tricky-Store-format staging file (bare or !/? suffixed lines,
+# [section] header lines allowed) as the new target list for the active
+# manager. txt backends get it verbatim; toml backends get the suffixes
+# stripped and folded into the injector's scoop array.
+ksm_commit_targets() {
+  _kct_src="$1"
+  case "$KSM_FORMAT" in
+    toml)
+      _kct_tmp="${KSM_TARGETS}.pkgs.$$"
+      : > "$_kct_tmp"
+      while IFS= read -r _kct_line || [ -n "$_kct_line" ]; do
+        [ -z "$_kct_line" ] && continue
+        case "$_kct_line" in \[*\]) continue ;; esac
+        _kct_base=$(_ksm_strip_suffix "$_kct_line")
+        [ -n "$_kct_base" ] && printf '%s\n' "$_kct_base" >> "$_kct_tmp"
+      done < "$_kct_src"
+      _toml_write_scoop "$KSM_TARGETS" < "$_kct_tmp"
+      rm -f "$_kct_tmp"
+      ksm_secure "$KSM_DIR" 0770
+      ksm_secure "$KSM_TARGETS" 0600
+      ksm_reload
+      unset _kct_line _kct_base _kct_tmp
+      ;;
+    *)
+      rm -f "${KSM_TARGETS}.bak"
+      [ -f "$KSM_TARGETS" ] && cp "$KSM_TARGETS" "${KSM_TARGETS}.bak"
+      mv -f "$_kct_src" "$KSM_TARGETS"
+      ksm_reload
+      ;;
+  esac
+  unset _kct_src
+}
+
+ksm_set_security_patch() {
+  _ksp_date="$1"
+  case "$KSM_FORMAT" in
+    toml)
+      _toml_set_trust_key "$KSM_SECURITY" "security_patch" "\"$_ksp_date\""
+      ksm_secure "$KSM_DIR" 0770
+      ksm_secure "$KSM_SECURITY" 0600
+      ;;
+    *)
+      printf 'all=%s\n' "$_ksp_date" > "$KSM_SECURITY" || { unset _ksp_date; return 1; }
+      ;;
+  esac
+  ksm_reload
+  unset _ksp_date
+}
+
+# Installs a keybox file for the active manager. MODE "copy" preserves SRC
+# (e.g. a user-provided custom keybox); default "move" consumes it (e.g. a
+# decoded download temp file).
+ksm_install_keybox() {
+  _kik_src="$1" _kik_mode="${2:-move}"
+  mkdir -p "$(dirname "$KSM_KEYBOX")" 2>/dev/null
+  if [ "$_kik_mode" = "copy" ]; then
+    cp "$_kik_src" "$KSM_KEYBOX" || { unset _kik_src _kik_mode; return 1; }
+  else
+    mv "$_kik_src" "$KSM_KEYBOX" || { unset _kik_src _kik_mode; return 1; }
+  fi
+  ksm_secure "$KSM_DIR" 0770
+  ksm_secure "$KSM_KEYBOX" 0600
+  ksm_reload
+  unset _kik_src _kik_mode
+}
+
+# -- TOML helpers (private) --
+# Deliberately minimal: only understands the two shapes Specter needs to
+# read/write (a top-level `scoop = [...]` array and a `KEY = VALUE` line
+# inside a `[trust]` table), not the full TOML grammar.
+
+_toml_read_scoop() {
+  _trs_file="$1"
+  [ -f "$_trs_file" ] || return 0
+  awk '
+    BEGIN { capture = 0 }
+    {
+      line = $0
+      if (!capture) {
+        if (line ~ /^[ ]*scoop[ ]*=/) {
+          capture = 1
+          sub(/^[ ]*scoop[ ]*=[ ]*/, "", line)
+        } else {
+          next
+        }
+      }
+      while (match(line, /"[^"]*"/)) {
+        print substr(line, RSTART + 1, RLENGTH - 2)
+        line = substr(line, RSTART + RLENGTH)
+      }
+      if (line ~ /\]/) capture = 0
+    }
+  ' "$_trs_file"
+}
+
+# Reads packages (one per line) from stdin and rewrites the `scoop` array
+# in FILE, preserving everything else. Idempotent: re-running with the same
+# input reproduces the same output byte-for-byte.
+_toml_write_scoop() {
+  _tws_file="$1"
+  _tws_block="${_tws_file}.block.$$"
+  {
+    printf 'scoop = [\n'
+    while IFS= read -r _tws_pkg || [ -n "$_tws_pkg" ]; do
+      [ -z "$_tws_pkg" ] && continue
+      printf '  "%s",\n' "$_tws_pkg"
+    done
+    printf ']\n'
+  } > "$_tws_block"
+
+  _tws_tmp="${_tws_file}.new.$$"
+
+  if [ -f "$_tws_file" ] && grep -Eq '^[ ]*scoop[ ]*=' "$_tws_file"; then
+    awk -v blockfile="$_tws_block" '
+      function emit(   line) { while ((getline line < blockfile) > 0) print line; close(blockfile) }
+      {
+        if (capture) { if ($0 ~ /\]/) capture = 0; next }
+        if ($0 ~ /^[ ]*scoop[ ]*=/) {
+          emit()
+          if ($0 !~ /\]/) capture = 1
+          next
+        }
+        print
+      }
+    ' "$_tws_file" > "$_tws_tmp"
+  elif [ -f "$_tws_file" ] && grep -Eq '^[ ]*\[' "$_tws_file"; then
+    awk -v blockfile="$_tws_block" '
+      function emit(   line) { while ((getline line < blockfile) > 0) print line; close(blockfile) }
+      BEGIN { injected = 0 }
+      {
+        if (!injected && $0 ~ /^[ ]*\[/) { emit(); injected = 1 }
+        print
+      }
+    ' "$_tws_file" > "$_tws_tmp"
+  else
+    cat "$_tws_block" > "$_tws_tmp"
+    if [ -f "$_tws_file" ] && [ -s "$_tws_file" ]; then
+      printf '\n' >> "$_tws_tmp"
+      cat "$_tws_file" >> "$_tws_tmp"
+    fi
+  fi
+
+  mv "$_tws_tmp" "$_tws_file"
+  rm -f "$_tws_block"
+  unset _tws_file _tws_block _tws_tmp _tws_pkg
+}
+
+# Sets KEY = VALUE inside the [trust] table of FILE, creating the table (and
+# the file) if needed. VALUE must already be TOML-formatted (quoted string,
+# bare number/bool, etc). Idempotent.
+_toml_set_trust_key() {
+  _tsk_file="$1" _tsk_key="$2" _tsk_val="$3"
+  _tsk_tmp="${_tsk_file}.new.$$"
+
+  if [ -f "$_tsk_file" ] && grep -Eq '^\[trust\]' "$_tsk_file"; then
+    awk -v key="$_tsk_key" -v val="$_tsk_val" '
+      BEGIN { in_trust = 0; done = 0 }
+      /^\[/ {
+        if (in_trust && !done) { print key " = " val; done = 1 }
+        in_trust = ($0 == "[trust]")
+        print
+        next
+      }
+      {
+        if (in_trust && !done && $0 ~ ("^[ ]*" key "[ ]*=")) {
+          print key " = " val
+          done = 1
+          next
+        }
+        print
+      }
+      END {
+        if (in_trust && !done) print key " = " val
+      }
+    ' "$_tsk_file" > "$_tsk_tmp"
+  else
+    if [ -f "$_tsk_file" ]; then cat "$_tsk_file" > "$_tsk_tmp"; else : > "$_tsk_tmp"; fi
+    printf '\n[trust]\n%s = %s\n' "$_tsk_key" "$_tsk_val" >> "$_tsk_tmp"
+  fi
+
+  mv "$_tsk_tmp" "$_tsk_file"
+  unset _tsk_file _tsk_key _tsk_val _tsk_tmp
+}

--- a/src/lib/target_common.sh
+++ b/src/lib/target_common.sh
@@ -41,31 +41,18 @@ _read_tee_status() {
 
 _merge_setup() {
   _count=0; _added=0
-  _TMP_EXIST="${TARGET_TXT}.exist.$$"
-  _TMP_TARGET="${TARGET_TXT}.new.$$"
+  _TMP_EXIST="$SPECTER_DIR/.target_exist.$$"
+  _TMP_TARGET="$SPECTER_DIR/.target_new.$$"
 }
 
 _merge_cleanup() {
-  rm -f "${TARGET_TXT}.bak" 2>/dev/null
-  [ -f "$TARGET_TXT" ] && cp "$TARGET_TXT" "${TARGET_TXT}.bak" 2>/dev/null
-  [ -f "$_TMP_TARGET" ] && mv -f "$_TMP_TARGET" "$TARGET_TXT"
+  [ -f "$_TMP_TARGET" ] && ksm_commit_targets "$_TMP_TARGET"
   unset _TMP_EXIST _TMP_TARGET _count _added
 }
 
 _merge_load_existing() {
-  if [ -f "$TARGET_TXT" ] && [ -s "$TARGET_TXT" ]; then
-    cp "$TARGET_TXT" "$_TMP_TARGET"
-    : > "$_TMP_EXIST"
-    tr -d '\r' < "$TARGET_TXT" 2>/dev/null | while IFS= read -r _line || [ -n "$_line" ]; do
-      [ -z "$_line" ] && continue
-      case "$_line" in \[*\]) continue ;; esac
-      _base=$(_normalize_pkg "$_line")
-      [ -n "$_base" ] && printf '%s\n' "$_base" >> "$_TMP_EXIST"
-    done
-  else
-    : > "$_TMP_TARGET"
-    : > "$_TMP_EXIST"
-  fi
+  ksm_read_targets_raw > "$_TMP_TARGET" 2>/dev/null || : > "$_TMP_TARGET"
+  ksm_read_targets > "$_TMP_EXIST" 2>/dev/null || : > "$_TMP_EXIST"
 }
 
 _normalize_pkg() {

--- a/src/service.sh
+++ b/src/service.sh
@@ -76,6 +76,8 @@ unset _bf _bf_default
 [ "$(cfg_get toggle_prop_handler 1)" != "0" ] && sh "$MODDIR/features/boot_state_props.sh" >"$SPECTER_DIR/log/boot_state_props.log" 2>&1 || true
 [ "$(cfg_get toggle_boot_hash 1)" != "0" ] && sh "$MODDIR/features/boot_hash.sh" >"$SPECTER_DIR/log/boot_hash.log" 2>&1 || true
 
+sh "$MODDIR/features/keystore_info.sh" >"$SPECTER_DIR/log/keystore_info.log" 2>&1 || true
+
 log_i "SERVICE" "Boot-time features done"
 
 ensure_dir "$SPECTER_DIR/backup" 2>/dev/null || true

--- a/src/uninstall.sh
+++ b/src/uninstall.sh
@@ -3,9 +3,10 @@ set -e
 MODDIR=${0%/*}
 . "$MODDIR/lib/common.sh"
 
-if [ -f "$BACKUP_FILE" ]; then
-    rm -f "$TARGET_FILE"
-    mv "$BACKUP_FILE" "$TARGET_FILE" || true
+detect_keystore_manager
+if [ -f "$BACKUP_FILE" ] && [ -n "$KSM_KEYBOX" ]; then
+    rm -f "$KSM_KEYBOX"
+    mv "$BACKUP_FILE" "$KSM_KEYBOX" || true
     log_i "UNINSTALL" "Restored original keybox from backup"
 fi
 

--- a/src/webroot/common/device-info.sh
+++ b/src/webroot/common/device-info.sh
@@ -18,8 +18,12 @@ _version=$(_escape_json "$(grep '^version=' "$MODULE_ROOT/module.prop" | cut -d'
 _root_type="$ROOT_TYPE"
 
 # Security patch date, real system value + optional spoofed value
+detect_keystore_manager
 _build_patch=$(getprop ro.build.version.security_patch 2>/dev/null || echo "")
-_patch_date=$(grep -E '^(boot|all)=' "$SECURITY_PATCH_FILE" 2>/dev/null | cut -d= -f2)
+case "$KSM_FORMAT" in
+  toml) _patch_date=$(grep -E '^[ ]*security_patch[ ]*=' "$KSM_SECURITY" 2>/dev/null | head -1 | sed 's/.*=[ ]*"\([^"]*\)".*/\1/') ;;
+  *) _patch_date=$(grep -E '^(boot|all)=' "$KSM_SECURITY" 2>/dev/null | cut -d= -f2) ;;
+esac
 [ -z "$_patch_date" ] && _patch_date="$_build_patch"
 
 # Flags

--- a/src/webroot/json/dev.json
+++ b/src/webroot/json/dev.json
@@ -33,5 +33,12 @@
     "role": "Chinese Translator",
     "github": "https://github.com/Nixie24",
     "avatar": "https://github.com/Nixie24.png"
+  },
+  {
+    "name": "Juan Martín",
+    "username": "juanma0511",
+    "role": "Backend Contributor",
+    "github": "https://github.com/juanma0511",
+    "avatar": "https://github.com/juanma0511.png"
   }
 ]

--- a/tests/mock_env.sh
+++ b/tests/mock_env.sh
@@ -13,8 +13,16 @@ bootstrap() {
   BIN_DIR="$TEST_ROOT/bin"; CONFIG_DIR="$TEST_ROOT/config"
   SPECTER_DIR="$TEST_ROOT/specter"; TRICKY_DIR="$TEST_ROOT/tricky_store"
   MODDIR="$TEST_ROOT"
-  mkdir -p "$PROPS_DIR" "$LOGS_DIR" "$BIN_DIR" "$CONFIG_DIR/val" "$SPECTER_DIR" "$TRICKY_DIR"
+  MODULES_BASE="$TEST_ROOT/modules"
+  OMK_MODULE="$MODULES_BASE/OhMyKeymint"
+  OMK_DIR="$TEST_ROOT/omk"
+  OMK_KEYBOX="$OMK_DIR/keybox.xml"
+  OMK_INJECTOR="$OMK_DIR/injector.toml"
+  OMK_CONFIG="$OMK_DIR/config.toml"
+  OMK_RESTART_DIR="$TEST_ROOT/omk_restart"
+  mkdir -p "$PROPS_DIR" "$LOGS_DIR" "$BIN_DIR" "$CONFIG_DIR/val" "$SPECTER_DIR" "$TRICKY_DIR" "$MODULES_BASE"
   export MOCK_DIR PROPS_DIR LOGS_DIR BIN_DIR CONFIG_DIR SPECTER_DIR TRICKY_DIR MODDIR
+  export MODULES_BASE OMK_MODULE OMK_DIR OMK_KEYBOX OMK_INJECTOR OMK_CONFIG OMK_RESTART_DIR
 
   cat > "$BIN_DIR/resetprop" << 'MOCK'
 #!/bin/sh
@@ -76,6 +84,7 @@ source_libs() {
   . "$REPO_ROOT/src/lib/detect.sh" 2>/dev/null
   . "$REPO_ROOT/src/lib/props.sh" 2>/dev/null
   . "$REPO_ROOT/src/lib/keybox.sh" 2>/dev/null
+  . "$REPO_ROOT/src/lib/keystore.sh" 2>/dev/null
   . "$REPO_ROOT/src/lib/conflicts.sh" 2>/dev/null
   SPECTER_DIR="$TEST_ROOT/specter"
   GMS_PROPS_FILE="$TEST_ROOT/gms_certified_props.json"
@@ -83,6 +92,27 @@ source_libs() {
   VBMETA_DIGEST="$SPECTER_DIR/vbmeta_digest"
   TEE_STATUS="$SPECTER_DIR/tee_status"
   TEE_BHASH="$SPECTER_DIR/tee_hash"
+  # constants.sh only sets these on first use (:=), so re-derive them from
+  # the current TRICKY_DIR/OMK_DIR on every call — otherwise they stick to
+  # whichever TEST_ROOT was active the first time source_libs ran.
+  TARGET_FILE="$TRICKY_DIR/keybox.xml"
+  BACKUP_FILE="$SPECTER_DIR/backup/keybox.xml.bak"
+  LOCKED_FILE="$TRICKY_DIR/locked.xml"
+  LOCKED_BACKUP="$SPECTER_DIR/backup/locked.xml.bak"
+  TARGET_TXT="$TRICKY_DIR/target.txt"
+  SECURITY_PATCH_FILE="$TRICKY_DIR/security_patch.txt"
+  BACKUP_DIR="$SPECTER_DIR/backup"
+  OMK_KEYBOX="$OMK_DIR/keybox.xml"
+  OMK_INJECTOR="$OMK_DIR/injector.toml"
+  OMK_CONFIG="$OMK_DIR/config.toml"
+}
+
+# Fakes an installed module by writing $MODULES_BASE/<id>/module.prop.
+mk_module() {
+  _mkm_id="$1" _mkm_name="$2"
+  mkdir -p "$MODULES_BASE/$_mkm_id"
+  printf 'name=%s\n' "$_mkm_name" > "$MODULES_BASE/$_mkm_id/module.prop"
+  unset _mkm_id _mkm_name
 }
 
 run_feature() {

--- a/tests/test_keystore.sh
+++ b/tests/test_keystore.sh
@@ -1,0 +1,261 @@
+plan "keystore.sh — manager detection, TOML helpers, target/security-patch commits"
+
+# ---------- detection: neither installed ----------
+bootstrap
+source_libs
+detect_keystore_manager
+assert_eq "detect: neither installed -> none" "none" "$KSM"
+
+# ---------- detection: Tricky Store only ----------
+bootstrap
+source_libs
+mk_module tricky_store "Tricky Store"
+detect_keystore_manager
+assert_eq "detect: tricky_store only -> trickystore" "trickystore" "$KSM"
+assert_eq "detect: format is txt" "txt" "$KSM_FORMAT"
+
+# ---------- detection: OMK only ----------
+bootstrap
+source_libs
+mk_module OhMyKeymint "OhMyKeymint"
+detect_keystore_manager
+assert_eq "detect: OhMyKeymint only -> omk" "omk" "$KSM"
+assert_eq "detect: format is toml" "toml" "$KSM_FORMAT"
+
+# ---------- detection: both installed, Tricky Store wins by default ----------
+bootstrap
+source_libs
+mk_module tricky_store "Tricky Store"
+mk_module OhMyKeymint "OhMyKeymint"
+detect_keystore_manager
+assert_eq "detect: both installed -> trickystore wins" "trickystore" "$KSM"
+
+# ---------- detection: override forces omk even with both installed ----------
+bootstrap
+source_libs
+mk_module tricky_store "Tricky Store"
+mk_module OhMyKeymint "OhMyKeymint"
+set_cfg "keystore_manager" "omk"
+detect_keystore_manager
+assert_eq "detect: override=omk wins" "omk" "$KSM"
+
+# ---------- detection: override=trickystore forces even if only OMK installed ----------
+bootstrap
+source_libs
+mk_module OhMyKeymint "OhMyKeymint"
+set_cfg "keystore_manager" "trickystore"
+detect_keystore_manager
+assert_eq "detect: override=trickystore forces" "trickystore" "$KSM"
+
+# ---------- ksm_available ----------
+bootstrap
+source_libs
+mk_module tricky_store "Tricky Store"
+detect_keystore_manager
+ksm_available && _avail=true || _avail=false
+assert_eq "available: tricky_store dir exists (mock creates it)" "true" "$_avail"
+
+bootstrap
+source_libs
+detect_keystore_manager
+ksm_available && _avail2=true || _avail2=false
+assert_eq "available: none -> false" "false" "$_avail2"
+
+# ---------- _toml_read_scoop / _toml_write_scoop round-trip ----------
+bootstrap
+source_libs
+_toml_file="$TEST_ROOT/injector.toml"
+cat > "$_toml_file" << 'EOF'
+[main]
+enable = true
+
+scoop = [
+  "com.google.android.gms",
+  "com.android.vending",
+]
+
+[filter]
+mode = "strict"
+EOF
+_scoop_out=$(_toml_read_scoop "$_toml_file")
+assert_contains "toml read: has gms" "$_scoop_out" "com.google.android.gms"
+assert_contains "toml read: has vending" "$_scoop_out" "com.android.vending"
+
+printf 'com.new.app\ncom.other.app\n' | _toml_write_scoop "$_toml_file"
+_scoop_out2=$(_toml_read_scoop "$_toml_file")
+assert_contains "toml write: has new.app" "$_scoop_out2" "com.new.app"
+assert_not_contains "toml write: old entries gone" "$_scoop_out2" "com.google.android.gms"
+assert_contains "toml write: preserves other sections" "$(cat "$_toml_file")" "[filter]"
+
+cp "$_toml_file" "${_toml_file}.snapshot"
+printf 'com.new.app\ncom.other.app\n' | _toml_write_scoop "$_toml_file"
+assert_eq "toml write: idempotent (same input -> same output)" "$(cat "${_toml_file}.snapshot")" "$(cat "$_toml_file")"
+
+# ---------- _toml_write_scoop: missing scoop key gets injected before first section ----------
+bootstrap
+source_libs
+_noscoop="$TEST_ROOT/noscoop.toml"
+cat > "$_noscoop" << 'EOF'
+[main]
+enable = true
+EOF
+printf 'pkg.one\n' | _toml_write_scoop "$_noscoop"
+assert_contains "toml write: injects scoop when absent" "$(cat "$_noscoop")" "scoop = ["
+_scoop_injected=$(_toml_read_scoop "$_noscoop")
+assert_eq "toml write: injected value readable" "pkg.one" "$_scoop_injected"
+
+# ---------- _toml_set_trust_key: existing key replaced ----------
+bootstrap
+source_libs
+_cfg_toml="$TEST_ROOT/config.toml"
+cat > "$_cfg_toml" << 'EOF'
+[trust]
+os_version = 17
+security_patch = "auto"
+
+[device]
+brand = "google"
+EOF
+_toml_set_trust_key "$_cfg_toml" security_patch '"2026-06-05"'
+assert_contains "trust key: replaced" "$(cat "$_cfg_toml")" 'security_patch = "2026-06-05"'
+assert_contains "trust key: sibling key untouched" "$(cat "$_cfg_toml")" "os_version = 17"
+assert_contains "trust key: other sections preserved" "$(cat "$_cfg_toml")" "[device]"
+
+cp "$_cfg_toml" "${_cfg_toml}.snapshot"
+_toml_set_trust_key "$_cfg_toml" security_patch '"2026-06-05"'
+assert_eq "trust key: idempotent" "$(cat "${_cfg_toml}.snapshot")" "$(cat "$_cfg_toml")"
+
+# ---------- _toml_set_trust_key: section exists without the key ----------
+bootstrap
+source_libs
+_cfg_toml2="$TEST_ROOT/config2.toml"
+cat > "$_cfg_toml2" << 'EOF'
+[trust]
+os_version = 17
+EOF
+_toml_set_trust_key "$_cfg_toml2" security_patch '"2026-06-05"'
+assert_contains "trust key: appended into existing section" "$(cat "$_cfg_toml2")" 'security_patch = "2026-06-05"'
+
+# ---------- _toml_set_trust_key: no [trust] section at all ----------
+bootstrap
+source_libs
+_cfg_toml3="$TEST_ROOT/config3.toml"
+cat > "$_cfg_toml3" << 'EOF'
+[main]
+foo = 1
+EOF
+_toml_set_trust_key "$_cfg_toml3" security_patch '"2026-06-05"'
+assert_contains "trust key: creates [trust] section" "$(cat "$_cfg_toml3")" "[trust]"
+assert_contains "trust key: value set in new section" "$(cat "$_cfg_toml3")" 'security_patch = "2026-06-05"'
+
+# ---------- ksm_set_security_patch: Tricky Store (txt) ----------
+bootstrap
+source_libs
+mk_module tricky_store "Tricky Store"
+detect_keystore_manager
+ksm_set_security_patch "2026-06-05"
+assert_file_eq "security patch txt: written as all=" "$KSM_SECURITY" "all=2026-06-05"
+assert_file_not_exists "security patch txt: no restart.all created" "$OMK_RESTART_DIR/restart.all"
+
+# ---------- ksm_set_security_patch: OMK (toml) ----------
+bootstrap
+source_libs
+mk_module OhMyKeymint "OhMyKeymint"
+mkdir -p "$OMK_DIR"
+cat > "$OMK_CONFIG" << 'EOF'
+[trust]
+os_version = 17
+security_patch = "auto"
+EOF
+detect_keystore_manager
+ksm_set_security_patch "2026-06-05"
+assert_contains "security patch toml: value set" "$(cat "$KSM_SECURITY")" 'security_patch = "2026-06-05"'
+assert_file_exists "security patch toml: restart.all created" "$OMK_RESTART_DIR/restart.all"
+
+# ---------- ksm_read_targets / ksm_commit_targets: Tricky Store preserves suffixes+comments ----------
+bootstrap
+source_libs
+mk_module tricky_store "Tricky Store"
+detect_keystore_manager
+cat > "$KSM_TARGETS" << 'EOF'
+[a section]
+android
+com.existing.app!
+EOF
+_kt_out=$(ksm_read_targets)
+assert_contains "targets txt read: bare form, no suffix" "$_kt_out" "com.existing.app"
+assert_not_contains "targets txt read: section header excluded" "$_kt_out" "["
+
+_kt_staging="$TEST_ROOT/staging_txt.txt"
+cat > "$_kt_staging" << 'EOF'
+[a section]
+android
+com.existing.app!
+com.new.app
+EOF
+ksm_commit_targets "$_kt_staging"
+assert_contains "targets txt commit: section preserved" "$(cat "$KSM_TARGETS")" "[a section]"
+assert_contains "targets txt commit: suffix preserved" "$(cat "$KSM_TARGETS")" "com.existing.app!"
+assert_contains "targets txt commit: new entry present" "$(cat "$KSM_TARGETS")" "com.new.app"
+assert_file_exists "targets txt commit: backup created" "${KSM_TARGETS}.bak"
+assert_file_not_exists "targets txt commit: no restart.all" "$OMK_RESTART_DIR/restart.all"
+
+# ---------- ksm_read_targets / ksm_commit_targets: OMK strips suffixes into scoop ----------
+bootstrap
+source_libs
+mk_module OhMyKeymint "OhMyKeymint"
+mkdir -p "$OMK_DIR"
+cat > "$OMK_INJECTOR" << 'EOF'
+[main]
+enable = true
+
+scoop = [
+  "android",
+]
+EOF
+detect_keystore_manager
+_kt_staging2="$TEST_ROOT/staging_toml.txt"
+cat > "$_kt_staging2" << 'EOF'
+android
+com.new.app!
+com.other.app?
+EOF
+ksm_commit_targets "$_kt_staging2"
+_kt_out2=$(ksm_read_targets)
+assert_contains "targets toml commit: new.app present, no suffix" "$_kt_out2" "com.new.app"
+assert_not_contains "targets toml commit: suffix stripped" "$_kt_out2" "com.new.app!"
+assert_contains "targets toml commit: other.app present" "$_kt_out2" "com.other.app"
+assert_file_exists "targets toml commit: restart.all created" "$OMK_RESTART_DIR/restart.all"
+assert_contains "targets toml commit: other sections preserved" "$(cat "$OMK_INJECTOR")" "[main]"
+
+# ---------- ksm_reload touches all three OMK restart triggers ----------
+bootstrap
+source_libs
+mk_module OhMyKeymint "OhMyKeymint"
+mkdir -p "$OMK_DIR"
+detect_keystore_manager
+ksm_reload
+assert_file_exists "reload: restart.keymint created" "$OMK_RESTART_DIR/restart.keymint"
+assert_file_exists "reload: restart.injector created" "$OMK_RESTART_DIR/restart.injector"
+assert_file_exists "reload: restart.all created" "$OMK_RESTART_DIR/restart.all"
+
+# ---------- ksm_reload is a no-op for Tricky Store ----------
+bootstrap
+source_libs
+mk_module tricky_store "Tricky Store"
+detect_keystore_manager
+ksm_reload
+assert_file_not_exists "reload: TS creates no restart.keymint" "$OMK_RESTART_DIR/restart.keymint"
+assert_file_not_exists "reload: TS creates no restart.all" "$OMK_RESTART_DIR/restart.all"
+
+# ---------- ksm_secure is a no-op for Tricky Store (files stay untouched) ----------
+bootstrap
+source_libs
+mk_module tricky_store "Tricky Store"
+detect_keystore_manager
+_sec_file="$TEST_ROOT/plain.txt"
+echo hi > "$_sec_file"
+ksm_secure "$_sec_file" 0600
+assert_file_exists "secure: TS leaves file in place" "$_sec_file"
+
+done_testing


### PR DESCRIPTION
## Description
This Pull Request introduces support for the **OhMyKeymint** keystore manager within the `omk` module. Additionally, it updates the development configuration to formally register a new backend contributor.

## Changes Made
* **OhMyKeymint Integration:** Implemented and integrated the `OhMyKeymint` keystore manager functionality.
* **Contributor Updates:** Added Juan Martín as a Backend Contributor in `dev.json`.

## Type of Change
- [x] New feature (feat)
- [ ] Bug fix (fix)
- [ ] Refactor / Maintenance
- [x] Configuration / Documentation

## How Has This Been Tested?
No issues.
- [x] Unit/Integration tests executed.
- [x] Verified in a local development environment.