### PR TITLE
fix: build-test workflow, TypeScript check, and target merge logging

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -31,7 +31,7 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Lint shell scripts
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: src
           severity: warning
@@ -51,7 +51,7 @@ jobs:
           test -f Module/META-INF/com/google/android/updater-script
           test -f Module/webroot/index.html
           test -f Module/lib/common.sh
-          test -f Module/lib/config_env.sh
+          test -f Module/lib/constants.sh
           test -f Module/webroot/json/module_paths.json
 
       - name: Check no hardcoded paths

--- a/src/action.sh
+++ b/src/action.sh
@@ -2,6 +2,7 @@
 set -e
 MODDIR=${0%/*}
 
+# shellcheck disable=SC3040
 case "$(readlink /proc/$$/exe 2>/dev/null)" in *busybox) set +o standalone; unset ASH_STANDALONE ;; esac
 
 . "$MODDIR/lib/common.sh"

--- a/src/features/target.sh
+++ b/src/features/target.sh
@@ -65,6 +65,7 @@ case "${1}" in
     _merge_cleanup
     : "${_added:=0}"
     log_i "TARGET" "Denylist merge: checked $_count entries, added $_added"
+    unset _count _added
     ;;
   --merge)
     log_i "TARGET" "Mode: merge"
@@ -100,6 +101,7 @@ case "${1}" in
     _merge_cleanup
     : "${_added:=0}"
     log_i "TARGET" "Checked $_count entries, added $_added"
+    unset _count _added
     ;;
   *)
     log_i "TARGET" "Mode: overwrite"

--- a/src/features/zygisk_next.sh
+++ b/src/features/zygisk_next.sh
@@ -19,7 +19,7 @@ ZN_NAME=$(grep "^name=" "$ZN_PROPFILE" | cut -d= -f2)
 log_i "ZYGISK_NEXT" "Detected: $ZN_NAME"
 
 case "$ZN_NAME" in
-  *Zygisk*Next*|*Zygisk-Next*|*ZygiskNext*)
+  *Zygisk*Next*)
     ;;
   *)
     log_e "ZYGISK_NEXT" "Unknown module '$ZN_NAME'"
@@ -29,8 +29,8 @@ esac
 
 ensure_dir "$ZN_DATA_DIR"
 
-echo -n 1 > "$ZN_DATA_DIR/denylist_enforce" && log_d "ZYGISK_NEXT" "denylist_enforce → 1"
-echo -n 1 > "$ZN_DATA_DIR/denylist_policy" && log_d "ZYGISK_NEXT" "denylist_policy → 1"
+printf '1' > "$ZN_DATA_DIR/denylist_enforce" && log_d "ZYGISK_NEXT" "denylist_enforce → 1"
+printf '1' > "$ZN_DATA_DIR/denylist_policy" && log_d "ZYGISK_NEXT" "denylist_policy → 1"
 
 log_i "ZYGISK_NEXT" "Applied denylist config"
 log_i "ZYGISK_NEXT" "Zygisk Next config complete"

--- a/src/lib/target_common.sh
+++ b/src/lib/target_common.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=sh
 # Shared routines for target.sh and target_merge.sh
-# Source after common.sh, paths.sh, package_list.sh, config_env.sh
+# Source after common.sh and constants.sh
 
 # Ensure blacklist exists
 _ensure_blacklist() {
@@ -47,7 +47,7 @@ _merge_setup() {
 
 _merge_cleanup() {
   [ -f "$_TMP_TARGET" ] && ksm_commit_targets "$_TMP_TARGET"
-  unset _TMP_EXIST _TMP_TARGET _count _added
+  unset _TMP_EXIST _TMP_TARGET
 }
 
 _merge_load_existing() {

--- a/src/lib/vbmeta.sh
+++ b/src/lib/vbmeta.sh
@@ -47,7 +47,7 @@ vbmeta_digest() {
   _total=$((256 + _auth + _aux))
   _aux_start=$((256 + _auth))
 
-  _digest=$(
+  _digest=$({
     dd if="$_part" bs=$_total count=1 2>/dev/null
     _pos=$((_aux_start + _desc_off))
     _end=$((_aux_start + _desc_off + _desc_sz))
@@ -65,7 +65,7 @@ vbmeta_digest() {
       fi
       _pos=$((_pos + 16 + _nbf))
     done
-  ) | sha256sum | cut -d' ' -f1
+  } | sha256sum | cut -d' ' -f1)
 
   [ -n "$_digest" ] && log_d "VBMETA" "Digest from $_part: $_digest"
   printf '%s' "$_digest"

--- a/src/webroot/js/bridge.ts
+++ b/src/webroot/js/bridge.ts
@@ -9,7 +9,11 @@ export async function initBridge(): Promise<void> {
   if (preloaded && typeof preloaded?.then === 'function') {
     try {
       const data = await preloaded;
-      if (data?.MODDIR) { MODULE = data; MODULE.MODDIR = MODULE.MODDIR.replace('/modules_update/', '/modules/'); return; }
+      if (data?.MODDIR) {
+        data.MODDIR = data.MODDIR.replace('/modules_update/', '/modules/');
+        MODULE = data;
+        return;
+      }
     } catch {}
   }
   try {

--- a/tests/test_vbmeta.sh
+++ b/tests/test_vbmeta.sh
@@ -24,7 +24,7 @@ assert_prop_eq "vbmeta: hash_alg preserved"    "ro.boot.vbmeta.hash_alg" "sha512
 bootstrap
 source_libs
 apply_vbmeta_props
-assert_prop_eq "vbmeta: avb_version set to default"          "ro.boot.vbmeta.avb_version" "1.2"
+assert_prop_eq "vbmeta: avb_version set to default"          "ro.boot.vbmeta.avb_version" "1.3"
 assert_prop_eq "vbmeta: hash_alg set to default"             "ro.boot.vbmeta.hash_alg" "sha256"
 assert_prop_eq "vbmeta: invalidate_on_error set to default"  "ro.boot.vbmeta.invalidate_on_error" "yes"
 assert_prop_eq "vbmeta: size set to default"                 "ro.boot.vbmeta.size" "4096"
@@ -35,6 +35,6 @@ source_libs
 rm -f "$VBMETA_DIGEST"
 apply_vbmeta_props
 assert_prop_not_set "vbmeta: digest not set when file missing" "ro.boot.vbmeta.digest"
-assert_prop_eq "vbmeta: avb_version still set" "ro.boot.vbmeta.avb_version" "1.2"
+assert_prop_eq "vbmeta: avb_version still set" "ro.boot.vbmeta.avb_version" "1.3"
 
 done_testing


### PR DESCRIPTION
Fixes CI failures and a target merge log issue:

- Update `build-test.yml` to use valid `actions/checkout@v4`, pin shellcheck, and check `constants.sh` instead of the removed `config_env.sh`
- Fix TypeScript null narrowing error in `bridge.ts`
- Update vbmeta test default from `1.2` to `1.3`
- Fix empty checked-count in target merge logs and clean up counters after logging
- Fix shellcheck warnings in `zygisk_next.sh`
- Fix vbmeta digest pipeline so the subshell output actually flows into `sha256sum`
- Suppress shellcheck warning for the busybox `standalone` option in `action.sh`

Verified with `npx tsc --noEmit`, `bash tests/run.sh`, `npm test`, `npm run build`, and `shellcheck --severity=warning`.
