### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Report a reproducible bug in Specter.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Report a reproducible bug. For setup help, use the [Telegram group](https://t.me/dpejoh0).
+
+  - type: input
+    id: version
+    attributes:
+      label: Specter version
+      description: Found in module.prop or the WebUI settings page.
+      placeholder: "e.g., 1.4.4-17"
+    validations:
+      required: true
+
+  - type: input
+    id: root_solution
+    attributes:
+      label: Root solution
+      description: Magisk, KernelSU, or APatch, plus version.
+      placeholder: "e.g., KernelSU 12018"
+    validations:
+      required: true
+
+  - type: input
+    id: android_version
+    attributes:
+      label: Android version
+      placeholder: "e.g., Android 15"
+    validations:
+      required: false
+
+  - type: textarea
+    id: other_modules
+    attributes:
+      label: Other installed modules
+      description: |
+        List modules that interact with Specter: Tricky Store / TEESimulator, PIF fork, Zygisk Next, HMA, etc.
+      placeholder: |
+        - Tricky Store v1.x
+        - KOWX712/PlayIntegrityFix
+        - Zygisk Next
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly. Include error messages and when it occurs.
+      placeholder: "Specter fails to set the security patch after boot..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Attach logs from the WebUI Export Logs button, action.sh, service.sh, or adb shell logcat.
+      placeholder: "Paste logs here. Redact sensitive info if needed."
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open the WebUI
+        2. Tap ...
+        3. Observe ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior
+      placeholder: |
+        Expected: ...
+        Actual: ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you've already tried
+      placeholder: "e.g., rebooted, cleared caches, reinstalled Specter..."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support & troubleshooting
+    url: https://t.me/dpejoh0
+    about: Ask setup and usage questions in the Telegram group, not in issues.
+  - name: Translations
+    url: https://crowdin.com/project/specter
+    about: Contribute translations via Crowdin.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Suggest a feature for Specter.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest a focused feature. Keep it within Specter's scope: root-device integrity, keybox, TEE, detection cleanup, and module automation.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line description of the feature.
+      placeholder: "e.g., Add a one-tap backup export button"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem it solves
+      description: What problem does this solve? Be specific.
+      placeholder: "Currently, exporting backups requires..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should it work? Keep it concrete.
+      placeholder: "Add a button in Settings that copies..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: fit
+    attributes:
+      label: Why it fits Specter
+      description: How does this align with Specter's goals? Optional, but useful.
+      placeholder: "This stays within Specter's scope by..."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      description: Can you help implement or test this?
+      options:
+        - label: I can help implement this
+        - label: I can help test this

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -44,11 +44,4 @@ body:
     validations:
       required: false
 
-  - type: checkboxes
-    id: contribute
-    attributes:
-      label: Contribution
-      description: Can you help implement or test this?
-      options:
-        - label: I can help implement this
-        - label: I can help test this
+


### PR DESCRIPTION
Adds issue templates to keep the tracker focused on actionable bugs and feature requests.

- Bug report: version, root solution, other modules, logs, repro steps
- Feature request: summary, problem, proposed solution, fit
- config.yml: redirects support to Telegram and translations to Crowdin