### PR TITLE
feat(ui): add tee broken status hint and translations

### DIFF
--- a/src/webroot/js/tee-bhash-ui.ts
+++ b/src/webroot/js/tee-bhash-ui.ts
@@ -81,7 +81,8 @@ function showResultDialog(teeStatus: string, teeHash: string, bootHash: string, 
     </div>`;
   }
 
-  const content = `<div class="tee-hash-row">
+  const content = `<p class="supporting-text">${t('tee_status_broken_hint', 'Broken means the hardware TEE is not responding. This is expected when a software attestation module is active.')}</p>
+    <div class="tee-hash-row">
       <span class="tee-hash-label">${t('tee_status_label', 'TEE Status')}</span>
       <span class="tee-hash-value">
         <span class="tee-status-badge ${statusClass}"><md-icon aria-hidden="true">${statusIcon}</md-icon> ${statusLabel}</span>

--- a/src/webroot/lang/ar.json
+++ b/src/webroot/lang/ar.json
@@ -319,6 +319,7 @@
   "tee_status_label": "حالة TEE",
   "tee_status_normal": "طبيعي",
   "tee_status_broken": "معطل",
+  "tee_status_broken_hint": "معطل يعني أن جهاز TEE الأساسي لا يستجيب. هذا أمر طبيعي عندما تكون وحدة مصادقة البرمجيات نشطة.",
   "tee_status_unknown": "غير معروف",
   "tee_status_error": "خطأ",
   "boot_hash": "تجزئة الإقلاع",

--- a/src/webroot/lang/es.json
+++ b/src/webroot/lang/es.json
@@ -319,6 +319,7 @@
   "tee_status_label": "Estado del TEE",
   "tee_status_normal": "Normal",
   "tee_status_broken": "Dañado",
+  "tee_status_broken_hint": "Dañado significa que el TEE del hardware no responde. Esto es normal cuando un módulo de atestación por software está activo.",
   "tee_status_unknown": "Desconocido",
   "tee_status_error": "Error",
   "boot_hash": "Hash de arranque",

--- a/src/webroot/lang/id.json
+++ b/src/webroot/lang/id.json
@@ -316,6 +316,7 @@
   "tee_status_label": "Status TEE",
   "tee_status_normal": "Normal",
   "tee_status_broken": "Rusak",
+  "tee_status_broken_hint": "Rusak berarti TEE perangkat keras tidak merespons. Ini normal ketika modul atestasi perangkat lunak aktif.",
   "tee_status_unknown": "Tidak diketahui",
   "tee_status_error": "Kesalahan",
   "boot_hash": "Boot Hash",

--- a/src/webroot/lang/pl.json
+++ b/src/webroot/lang/pl.json
@@ -316,6 +316,7 @@
   "tee_status_label": "Status TEE",
   "tee_status_normal": "Normalny",
   "tee_status_broken": "Uszkodzony",
+  "tee_status_broken_hint": "Uszkodzony oznacza, że sprzętowy TEE nie odpowiada. Jest to oczekiwane, gdy aktywny jest moduł atestacji programowej.",
   "tee_status_unknown": "Nieznany",
   "tee_status_error": "Błąd",
   "boot_hash": "Boot Hash",

--- a/src/webroot/lang/ru.json
+++ b/src/webroot/lang/ru.json
@@ -322,6 +322,7 @@
   "tee_status_label": "Состояние TEE",
   "tee_status_normal": "Нормальный",
   "tee_status_broken": "Сломан",
+  "tee_status_broken_hint": "Сломан означает, что аппаратный TEE не отвечает. Это ожидаемо, когда активен модуль программной аттестации.",
   "tee_status_unknown": "Неизвестно",
   "tee_status_error": "Ошибка",
   "boot_hash": "Хэш загрузки",

--- a/src/webroot/lang/source/string.json
+++ b/src/webroot/lang/source/string.json
@@ -316,6 +316,7 @@
   "tee_status_label": "TEE Status",
   "tee_status_normal": "Normal",
   "tee_status_broken": "Broken",
+  "tee_status_broken_hint": "Broken means the hardware TEE is not responding. This is expected when a software attestation module is active.",
   "tee_status_unknown": "Unknown",
   "tee_status_error": "Error",
   "boot_hash": "Boot Hash",

--- a/src/webroot/lang/tr.json
+++ b/src/webroot/lang/tr.json
@@ -316,7 +316,7 @@
   "tee_status_label": "TEE Durumu",
   "tee_status_normal": "Normal",
   "tee_status_broken": "Kırık",
-  "tee_status_broken_hint": "Kırık, donanım TEE'sinin yanıt vermediği anlamına gelir. Bir yazılım atestasyon modülü aktifken bu normaldir.",
+  "tee_status_broken_hint": "Kırık, gerçek cihaz TEE'sinin yanıt vermediği anlamına gelir. TEE simulasyon modülü kullanıldığı için bu normaldir, bu bir hata değildir.",
   "tee_status_unknown": "Bilinmiyor",
   "tee_status_error": "Hata",
   "boot_hash": "Boot Hash",

--- a/src/webroot/lang/tr.json
+++ b/src/webroot/lang/tr.json
@@ -316,6 +316,7 @@
   "tee_status_label": "TEE Durumu",
   "tee_status_normal": "Normal",
   "tee_status_broken": "Kırık",
+  "tee_status_broken_hint": "Kırık, donanım TEE'sinin yanıt vermediği anlamına gelir. Bir yazılım atestasyon modülü aktifken bu normaldir.",
   "tee_status_unknown": "Bilinmiyor",
   "tee_status_error": "Hata",
   "boot_hash": "Boot Hash",

--- a/src/webroot/lang/zh.json
+++ b/src/webroot/lang/zh.json
@@ -319,6 +319,7 @@
   "tee_status_label": "TEE 状态",
   "tee_status_normal": "正常",
   "tee_status_broken": "已损坏",
+  "tee_status_broken_hint": "已损坏表示硬件 TEE 未响应。当软件证明模块处于活动状态时，这是正常现象。",
   "tee_status_unknown": "未知",
   "tee_status_error": "错误",
   "boot_hash": "启动哈希",


### PR DESCRIPTION
Adds an educational hint to the TEE & Boot Hash dialog explaining that **Broken** TEE status is expected when a software attestation module is active.

- Adds `tee_status_broken_hint` to source strings and all supported translations (ar, es, id, pl, ru, tr, zh).
- Renders the hint above the TEE Status row in the result dialog.
