### PR TITLE
fix(detect): do not treat stale omk data dir as installed module

### DIFF
--- a/src/lib/detect.sh
+++ b/src/lib/detect.sh
@@ -76,7 +76,6 @@ _omk_prop() {
     done
   done
   [ -f "$OMK_MODULE/module.prop" ] && { grep "^name=" "$OMK_MODULE/module.prop" 2>/dev/null | cut -d= -f2; return 0; }
-  [ -d "$OMK_DIR" ] && { echo "OhMyKeymint"; return 0; }
   echo ""
 }
 

--- a/tests/test_keystore.sh
+++ b/tests/test_keystore.sh
@@ -6,6 +6,13 @@ source_libs
 detect_keystore_manager
 assert_eq "detect: neither installed -> none" "none" "$KSM"
 
+# ---------- detection: stale OMK data dir without module -> none ----------
+bootstrap
+source_libs
+mkdir -p "$OMK_DIR"
+detect_keystore_manager
+assert_eq "detect: stale omk dir without module -> none" "none" "$KSM"
+
 # ---------- detection: Tricky Store only ----------
 bootstrap
 source_libs


### PR DESCRIPTION
Stops `_omk_prop()` from reporting OhMyKeymint as installed just because `/data/misc/keystore/omk` still exists. That directory can be left behind after OMK is uninstalled, causing Specter to mis-detect the active keystore manager and try to write OMK-format files.

- Removes the `/data/misc/keystore/omk` directory fallback from `_omk_prop()`.
- OMK is now detected only by its actual module directory/module.prop, matching how Tricky Store is detected.
- Adds a regression test: stale OMK data dir without a module returns `none`.
