### PR TITLE
feat: hot install — apply module updates without reboot (KernelSU)

### DIFF
--- a/src/customize.sh
+++ b/src/customize.sh
@@ -115,7 +115,15 @@ unset _arch _src _f
 mkdir -p "$SPECTER_DIR/config"
 cp "$MODPATH/config/conflicts.txt" "$SPECTER_DIR/config/conflicts.txt" 2>/dev/null || true
 
-ui_print ""
-ui_print " >> First-boot setup: backup, target, security patch, keybox (next reboot)"
+# Hot install — ksu-only, update-already-present: move staging into the
+# live dir and re-apply without a reboot. no-op on apatch/magisk/first install.
+. "$MODPATH/lib/hotinstall.sh"
+specter_hot_install
+
+# The "next reboot" message only applies when we didn't just live-apply.
+if [ -z "${_specter_hot_done:-}" ]; then
+  ui_print ""
+  ui_print " >> First-boot setup: backup, target, security patch, keybox (next reboot)"
+fi
 
 return 0

--- a/src/features/tee.sh
+++ b/src/features/tee.sh
@@ -43,7 +43,8 @@ if [ ! -f "$_dex" ]; then
   exit 1
 fi
 
-sleep 5
+# Wait for keystore/Binder at boot; skip on hot install — system is already up.
+[ "${SPECTER_HOT_INSTALL:-0}" = "1" ] || sleep 5
 timeout 15 /system/bin/app_process -Djava.class.path="$_dex" / com.dpejoh.specter.Main "$SPECTER_DIR" 2>&1 || true
 unset _dex
 

--- a/src/hotinstall.sh
+++ b/src/hotinstall.sh
@@ -1,0 +1,61 @@
+#!/system/bin/sh
+set -e
+MODDIR=${0%/*}
+
+. "$MODDIR/lib/common.sh"
+export ROOT_SOL
+
+# Skip tee.sh's boot-time sleep — the system is already running.
+SPECTER_HOT_INSTALL=1
+export SPECTER_HOT_INSTALL
+
+HOT_LOG="$SPECTER_DIR/log/hotinstall.log"
+ensure_dir "$SPECTER_DIR/log" 2>/dev/null || true
+log_rotate "$HOT_LOG" 2>/dev/null || true
+
+# Parent (specter_hot_install, running in customize.sh) reads this back to
+# decide whether to print the apply-failed warning — exit status across a
+# streaming pipe isn't reliable in POSIX sh.
+rm -f "$SPECTER_DIR/.hotinstall_failed"
+
+{
+  log_i "HOT" "Hot-install live-apply starting"
+
+  # customize.sh clears tee_status/tee_tier on every install; service.sh would
+  # re-run tee.sh at boot to repopulate them, but we skip service.sh. Run it
+  # here, before action.sh — device-info.sh reads the cached files to build
+  # info.json for the WebUI.
+  log_i "HOT" "Refreshing TEE status"
+  sh "$MODDIR/features/tee.sh" || log_w "HOT" "tee.sh failed (TEE indicator may be stale until reboot)"
+
+  # Kill the boot-time scheduler + its inotifyd children — it's still running
+  # pre-update code sourced before the dir move.
+  _old_pid="$(cat "$SPECTER_DIR/scheduler.pid" 2>/dev/null || true)"
+  if [ -n "$_old_pid" ]; then
+    for _child in $(pgrep -P "$_old_pid" 2>/dev/null || true); do
+      kill "$_child" 2>/dev/null || true
+    done
+    unset _child
+    kill "$_old_pid" 2>/dev/null || true
+    rm -f "$SPECTER_DIR/scheduler.pid"
+  fi
+  unset _old_pid
+
+  if [ "$(cfg_get toggle_scheduler 1)" != "0" ]; then
+    sh "$MODDIR/lib/scheduler.sh" >"$SPECTER_DIR/log/scheduler.log" 2>&1 &
+    log_i "HOT" "Scheduler relaunched (PID $!)"
+  fi
+
+  log_i "HOT" "Running action.sh"
+  if sh "$MODDIR/action.sh"; then
+    log_i "HOT" "action.sh completed"
+  else
+    _rc=$?
+    log_e "HOT" "action.sh failed (exit $_rc)"
+    : > "$SPECTER_DIR/.hotinstall_failed"
+  fi
+
+  log_i "HOT" "Hot-install live-apply done"
+} 2>&1 | tee -a "$HOT_LOG"
+
+exit 0

--- a/src/hotinstall.sh
+++ b/src/hotinstall.sh
@@ -13,23 +13,17 @@ HOT_LOG="$SPECTER_DIR/log/hotinstall.log"
 ensure_dir "$SPECTER_DIR/log" 2>/dev/null || true
 log_rotate "$HOT_LOG" 2>/dev/null || true
 
-# Parent (specter_hot_install, running in customize.sh) reads this back to
-# decide whether to print the apply-failed warning — exit status across a
-# streaming pipe isn't reliable in POSIX sh.
+# Parent reads this back; exit status across the streaming pipe isn't reliable.
 rm -f "$SPECTER_DIR/.hotinstall_failed"
 
 {
   log_i "HOT" "Hot-install live-apply starting"
 
-  # customize.sh clears tee_status/tee_tier on every install; service.sh would
-  # re-run tee.sh at boot to repopulate them, but we skip service.sh. Run it
-  # here, before action.sh — device-info.sh reads the cached files to build
-  # info.json for the WebUI.
+  # service.sh is skipped, so refresh TEE status here for the WebUI info.json.
   log_i "HOT" "Refreshing TEE status"
   sh "$MODDIR/features/tee.sh" || log_w "HOT" "tee.sh failed (TEE indicator may be stale until reboot)"
 
-  # Kill the boot-time scheduler + its inotifyd children — it's still running
-  # pre-update code sourced before the dir move.
+  # Kill the boot-time scheduler + its inotifyd children (pre-update code).
   _old_pid="$(cat "$SPECTER_DIR/scheduler.pid" 2>/dev/null || true)"
   if [ -n "$_old_pid" ]; then
     for _child in $(pgrep -P "$_old_pid" 2>/dev/null || true); do
@@ -57,5 +51,3 @@ rm -f "$SPECTER_DIR/.hotinstall_failed"
 
   log_i "HOT" "Hot-install live-apply done"
 } 2>&1 | tee -a "$HOT_LOG"
-
-exit 0

--- a/src/lib/hotinstall.sh
+++ b/src/lib/hotinstall.sh
@@ -1,0 +1,63 @@
+# shellcheck shell=sh
+# Hot-install support — move a staged update into the live dir and re-apply
+# without a reboot. Sourced by customize.sh; never executed directly.
+
+specter_hot_install() {
+  # KernelSU family only. The live-move trick depends on the root solution's
+  # mount internals; proven for ksu, unverified for apatch, and magisk binds
+  # modules at boot so a live move is a no-op there.
+  [ "$ROOT_SOL" = "kernelsu" ] || return 0
+
+  _hi_modid="$(basename "${MODPATH:-}")"
+  [ -n "$_hi_modid" ] || return 0
+  _hi_live="$MODULES_BASE/$_hi_modid"
+  _hi_stage="${MODULES_BASE}_update/$_hi_modid"
+
+  # Only on an update — first install still needs a reboot.
+  [ -d "$_hi_live" ] || return 0
+  [ -d "$_hi_stage" ] || return 0
+
+  ui_print "- Hot install requested ($ROOT_TYPE)"
+
+  rm -rf "$_hi_live"
+  mv "$_hi_stage" "$_hi_live"
+
+  # Hot install satisfies the post-update obligation itself; clear the token
+  # so the next real reboot won't re-run first_boot_setup in conservative mode
+  # and clobber what we just applied.
+  rm -f "$SPECTER_DIR/.first_boot_pending" 2>/dev/null || true
+
+  _specter_hot_done=1
+
+  # Stream the executor's output line-by-line to ui_print so the install
+  # doesn't appear stalled during the ~30s integrity pipeline.
+  ui_print "- Applying update (TEE refresh + scheduler + integrity pipeline)..."
+  rm -f "$SPECTER_DIR/.hotinstall_failed"
+  sh "$_hi_live/hotinstall.sh" 2>&1 | while IFS= read -r _hiline; do
+    [ -n "$_hiline" ] && ui_print "    $_hiline"
+  done
+  if [ -f "$SPECTER_DIR/.hotinstall_failed" ]; then
+    _hi_apply_failed=1
+    rm -f "$SPECTER_DIR/.hotinstall_failed"
+  else
+    _hi_apply_failed=0
+  fi
+  unset _hiline
+
+  # Recreate a stub module.prop in the staging dir so ksu's ensure_file_exists
+  # bookkeeping finds it intact, then background its removal once the manager
+  # has settled. Self-cleaning even if a future ksu doesn't need it.
+  _hi_delay="${SPECTER_HOT_CLEANUP_DELAY:-3}"
+  mkdir -p "$_hi_stage"
+  cp "$_hi_live/module.prop" "$_hi_stage/module.prop" 2>/dev/null || true
+  ( sleep "$_hi_delay"; rm -rf "$_hi_live/update" 2>/dev/null; rm -rf "$_hi_stage" 2>/dev/null ) &
+
+  ui_print "- Refresh module page after installation"
+  if [ "$_hi_apply_failed" = "1" ]; then
+    ui_print "- WARNING: live-apply failed; run action.sh from WebUI or reboot"
+  else
+    ui_print "- No need to reboot"
+  fi
+
+  unset _hi_modid _hi_live _hi_stage _hi_apply_failed _hi_delay
+}

--- a/src/lib/hotinstall.sh
+++ b/src/lib/hotinstall.sh
@@ -1,11 +1,8 @@
 # shellcheck shell=sh
-# Hot-install support — move a staged update into the live dir and re-apply
-# without a reboot. Sourced by customize.sh; never executed directly.
+# Move a staged update into the live dir and re-apply without a reboot.
 
 specter_hot_install() {
-  # KernelSU family only. The live-move trick depends on the root solution's
-  # mount internals; proven for ksu, unverified for apatch, and magisk binds
-  # modules at boot so a live move is a no-op there.
+  # KernelSU family only; the live-move trick relies on ksu mount internals.
   [ "$ROOT_SOL" = "kernelsu" ] || return 0
 
   _hi_modid="$(basename "${MODPATH:-}")"
@@ -13,7 +10,7 @@ specter_hot_install() {
   _hi_live="$MODULES_BASE/$_hi_modid"
   _hi_stage="${MODULES_BASE}_update/$_hi_modid"
 
-  # Only on an update — first install still needs a reboot.
+  # Updates only; first install still needs a reboot.
   [ -d "$_hi_live" ] || return 0
   [ -d "$_hi_stage" ] || return 0
 
@@ -22,38 +19,30 @@ specter_hot_install() {
   rm -rf "$_hi_live"
   mv "$_hi_stage" "$_hi_live"
 
-  # Hot install satisfies the post-update obligation itself; clear the token
-  # so the next real reboot won't re-run first_boot_setup in conservative mode
-  # and clobber what we just applied.
+  # Clear the token so the next reboot won't re-run first_boot_setup over this.
   rm -f "$SPECTER_DIR/.first_boot_pending" 2>/dev/null || true
 
   _specter_hot_done=1
 
-  # Stream the executor's output line-by-line to ui_print so the install
-  # doesn't appear stalled during the ~30s integrity pipeline.
   ui_print "- Applying update (TEE refresh + scheduler + integrity pipeline)..."
   rm -f "$SPECTER_DIR/.hotinstall_failed"
   sh "$_hi_live/hotinstall.sh" 2>&1 | while IFS= read -r _hiline; do
     [ -n "$_hiline" ] && ui_print "    $_hiline"
   done
   if [ -f "$SPECTER_DIR/.hotinstall_failed" ]; then
-    _hi_apply_failed=1
     rm -f "$SPECTER_DIR/.hotinstall_failed"
-  else
-    _hi_apply_failed=0
+    _hi_apply_failed=1
   fi
   unset _hiline
 
-  # Recreate a stub module.prop in the staging dir so ksu's ensure_file_exists
-  # bookkeeping finds it intact, then background its removal once the manager
-  # has settled. Self-cleaning even if a future ksu doesn't need it.
+  # Recreate a stub module.prop so ksu bookkeeping finds it, then clean up later.
   _hi_delay="${SPECTER_HOT_CLEANUP_DELAY:-3}"
   mkdir -p "$_hi_stage"
   cp "$_hi_live/module.prop" "$_hi_stage/module.prop" 2>/dev/null || true
   ( sleep "$_hi_delay"; rm -rf "$_hi_live/update" 2>/dev/null; rm -rf "$_hi_stage" 2>/dev/null ) &
 
   ui_print "- Refresh module page after installation"
-  if [ "$_hi_apply_failed" = "1" ]; then
+  if [ "${_hi_apply_failed:-0}" = "1" ]; then
     ui_print "- WARNING: live-apply failed; run action.sh from WebUI or reboot"
   else
     ui_print "- No need to reboot"

--- a/tests/test_hotinstall.sh
+++ b/tests/test_hotinstall.sh
@@ -1,0 +1,200 @@
+plan "lib/hotinstall.sh — specter_hot_install gating, move, cleanup dance, messaging"
+
+# Helpers --------------------------------------------------------------------
+_hi_setup() {
+  # $1 = modid (defaults to "specter")
+  _modid="${1:-specter}"
+  ROOT_SOL="kernelsu"
+  ROOT_TYPE="KernelSU"
+  _mods_update="${MODULES_BASE}_update"
+  MODPATH="$_mods_update/$_modid"
+  STAGE="$MODPATH"
+  LIVE="$MODULES_BASE/$_modid"
+
+  # Pre-existing live dir (this is an update, not first install)
+  rm -rf "$LIVE" "$_mods_update"
+  mkdir -p "$LIVE"
+  printf 'id=%s\nname=OldVersion\nversionCode=1\n' "$_modid" > "$LIVE/module.prop"
+
+  # Staging dir the manager runs customize.sh from
+  mkdir -p "$STAGE"
+  printf 'id=%s\nname=NewVersion\nversionCode=2\n' "$_modid" > "$STAGE/module.prop"
+  # Executor stub: $2 controls exit code (default 0). Writes a marker next to
+  # itself (in the live dir, post-move) so we can prove the live copy ran.
+  # Also prints a line so we can assert the streaming-pipe reaches ui_print.
+  # On failure (rc!=0) writes the status marker the real hotinstall.sh would.
+  _hi_exec_rc="${2:-0}"
+  if [ "$_hi_exec_rc" = "0" ]; then
+    printf '#!/bin/sh\necho stub-running\necho ran > "$(dirname "$0")/hi.ran"\nexit 0\n' > "$STAGE/hotinstall.sh"
+  else
+    printf '#!/bin/sh\necho stub-running\necho ran > "$(dirname "$0")/hi.ran"\n: > "$SPECTER_DIR/.hotinstall_failed"\nexit %s\n' "$_hi_exec_rc" > "$STAGE/hotinstall.sh"
+  fi
+  chmod +x "$STAGE/hotinstall.sh"
+
+  # First-boot token present (customize.sh touches it on every install)
+  : > "$SPECTER_DIR/.first_boot_pending"
+
+  # ui_print mock
+  UI_LOG="$TEST_ROOT/ui.log"; : > "$UI_LOG"
+  ui_print() { echo "$@" >> "$UI_LOG"; }
+
+  # Fast cleanup delay so tests don't sleep 3s
+  SPECTER_HOT_CLEANUP_DELAY=0
+  export SPECTER_HOT_CLEANUP_DELAY
+
+  unset _modid
+}
+
+. "$REPO_ROOT/src/lib/hotinstall.sh"
+
+# ---- gate: APatch skipped ----
+bootstrap
+source_libs
+_hi_setup
+ROOT_SOL="apatch"
+specter_hot_install
+assert_file_eq "apatch: live unchanged (old prop)" "$LIVE/module.prop" "$(printf 'id=specter\nname=OldVersion\nversionCode=1\n')"
+assert_eq "apatch: no hot-done marker" "" "${_specter_hot_done:-}"
+assert_not_contains "apatch: ui silent on hot install" "$(cat "$UI_LOG")" "Hot install requested"
+# staging still intact (move did not happen)
+assert_file_exists "apatch: staging intact" "$STAGE/module.prop"
+
+# ---- gate: first install skipped (no live dir) ----
+bootstrap
+source_libs
+_hi_setup
+rm -rf "$LIVE"   # first install: live not present yet
+specter_hot_install
+assert_file_exists "first-install: staging intact" "$STAGE/module.prop"
+assert_eq "first-install: no hot-done marker" "" "${_specter_hot_done:-}"
+
+# ---- gate: missing staging skipped ----
+bootstrap
+source_libs
+_hi_setup
+rm -rf "${MODULES_BASE}_update"
+specter_hot_install
+assert_file_eq "no-staging: live unchanged" "$LIVE/module.prop" "$(printf 'id=specter\nname=OldVersion\nversionCode=1\n')"
+
+# ---- happy path: ksu update moves staging -> live ----
+bootstrap
+source_libs
+_hi_setup
+specter_hot_install
+assert_file_eq "ksu: live has new module.prop" "$LIVE/module.prop" "$(printf 'id=specter\nname=NewVersion\nversionCode=2\n')"
+assert_file_exists "ksu: executor ran from live dir" "$LIVE/hi.ran"
+assert_file_not_exists "ksu: first_boot_pending removed" "$SPECTER_DIR/.first_boot_pending"
+assert_eq "ksu: hot-done marker set" "1" "${_specter_hot_done:-}"
+_ui="$(cat "$UI_LOG")"
+assert_contains "ksu: ui announces hot install" "$_ui" "Hot install requested"
+assert_contains "ksu: ui says no reboot" "$_ui" "No need to reboot"
+assert_not_contains "ksu: no apply-fail warning" "$_ui" "WARNING"
+assert_contains "ksu: executor output streamed to ui" "$_ui" "stub-running"
+assert_contains "ksu: ui pre-announces apply" "$_ui" "Applying update"
+
+# ---- cleanup dance: stub module.prop recreated, then staging removed ----
+bootstrap
+source_libs
+_hi_setup
+specter_hot_install
+assert_file_exists "dance: stub module.prop in staging" "${STAGE}/module.prop"
+sleep 1
+assert_file_not_exists "dance: staging removed after delay" "${STAGE}/module.prop"
+assert_file_not_exists "dance: live/update marker removed" "$LIVE/update"
+
+# ---- apply failure: warning printed, install still considered done ----
+bootstrap
+source_libs
+_hi_setup "specter" 1   # executor exits 1
+specter_hot_install
+assert_file_eq "fail: live still got new code" "$LIVE/module.prop" "$(printf 'id=specter\nname=NewVersion\nversionCode=2\n')"
+assert_eq "fail: hot-done marker still set" "1" "${_specter_hot_done:-}"
+_ui="$(cat "$UI_LOG")"
+assert_contains "fail: ui warns about apply failure" "$_ui" "WARNING: live-apply failed"
+assert_not_contains "fail: ui does not promise no-reboot" "$_ui" "No need to reboot"
+
+# ---- non-specter module id is respected (no hardcoding) ----
+bootstrap
+source_libs
+_hi_setup "myfork"
+specter_hot_install
+assert_file_eq "modid: myfork live updated" "$MODULES_BASE/myfork/module.prop" "$(printf 'id=myfork\nname=NewVersion\nversionCode=2\n')"
+assert_file_exists "modid: myfork executor ran" "$MODULES_BASE/myfork/hi.ran"
+
+# ---- real executor: src/hotinstall.sh invokes tee.sh + action.sh, streams to ui_print ----
+# Replace the stub hotinstall.sh with the REAL src/hotinstall.sh and stub its
+# siblings (features/tee.sh, action.sh, lib/scheduler.sh). This catches
+# regressions in the actual executor — e.g. "did we forget to call tee.sh?"
+# — that a stub-based test cannot.
+bootstrap
+source_libs
+_hi_setup
+rm -f "$STAGE/hotinstall.sh"
+cp "$REPO_ROOT/src/hotinstall.sh" "$STAGE/hotinstall.sh"
+chmod +x "$STAGE/hotinstall.sh"
+# Stub: features/tee.sh — writes a marker so we can prove it ran
+mkdir -p "$STAGE/features"
+printf '#!/bin/sh\necho tee_ok > "$SPECTER_DIR/tee.ran"\n' > "$STAGE/features/tee.sh"
+chmod +x "$STAGE/features/tee.sh"
+# Stub: action.sh — writes a marker; uses set -e-safe pattern (real action.sh)
+printf '#!/bin/sh\necho ACTION-OK\necho ran > "$SPECTER_DIR/act.ran"\nexit 0\n' > "$STAGE/action.sh"
+chmod +x "$STAGE/action.sh"
+# Stub: lib/scheduler.sh — exits immediately; sched loop never starts in tests
+mkdir -p "$STAGE/lib"
+printf '#!/bin/sh\nexit 0\n' > "$STAGE/lib/scheduler.sh"
+# Stub lib/common.sh needs to be available — the real common.sh sources more
+# libs. Use a minimal stub so we don't drag in detect/keystore/network etc. that
+# rely on Android runtime. Plus a stub log_i/log_w/log_e/log_d/log_rotate.
+cat > "$STAGE/lib/common.sh" << 'COMMON_EOF'
+log_d() { :; }
+log_i() { echo "$2"; }
+log_w() { echo "Warning: $2"; }
+log_e() { echo "Error: $2" >&2; }
+log_rotate() { :; }
+cfg_get() { echo "${2:-}"; }
+ensure_dir() { mkdir -p "$1" 2>/dev/null; }
+COMMON_EOF
+# Pre-seed the scheduler pid file so the kill path runs (proves it tolerates
+# a missing process: kill on a non-existent pid just fails silently).
+echo "99999" > "$SPECTER_DIR/scheduler.pid"
+specter_hot_install
+assert_file_exists "real-exec: tee.sh ran (TEE cache refresh)" "$SPECTER_DIR/tee.ran"
+assert_file_exists "real-exec: action.sh ran" "$SPECTER_DIR/act.ran"
+assert_file_not_exists "real-exec: no failure marker on success" "$SPECTER_DIR/.hotinstall_failed"
+_ui="$(cat "$UI_LOG")"
+assert_contains "real-exec: HOT line streamed" "$_ui" "Hot-install live-apply starting"
+assert_contains "real-exec: tee refresh announced" "$_ui" "Refreshing TEE status"
+assert_contains "real-exec: action.sh announced" "$_ui" "Running action.sh"
+assert_contains "real-exec: action.sh child output streamed (ACTION-OK)" "$_ui" "ACTION-OK"
+assert_contains "real-exec: done line streamed" "$_ui" "Hot-install live-apply done"
+
+# ---- real executor: action.sh failure writes status marker, hot install warns ----
+bootstrap
+source_libs
+_hi_setup
+rm -f "$STAGE/hotinstall.sh"
+cp "$REPO_ROOT/src/hotinstall.sh" "$STAGE/hotinstall.sh"
+chmod +x "$STAGE/hotinstall.sh"
+mkdir -p "$STAGE/features" "$STAGE/lib"
+printf '#!/bin/sh\necho tee_ok > "$SPECTER_DIR/tee.ran"\n' > "$STAGE/features/tee.sh"
+chmod +x "$STAGE/features/tee.sh"
+printf '#!/bin/sh\necho ACTION-FAIL\nexit 7\n' > "$STAGE/action.sh"
+chmod +x "$STAGE/action.sh"
+printf '#!/bin/sh\nexit 0\n' > "$STAGE/lib/scheduler.sh"
+cat > "$STAGE/lib/common.sh" << 'COMMON_EOF'
+log_d() { :; }
+log_i() { echo "$2"; }
+log_w() { echo "Warning: $2"; }
+log_e() { echo "Error: $2" >&2; }
+log_rotate() { :; }
+cfg_get() { echo "${2:-}"; }
+ensure_dir() { mkdir -p "$1" 2>/dev/null; }
+COMMON_EOF
+specter_hot_install
+assert_file_exists "real-exec-fail: tee.sh still ran" "$SPECTER_DIR/tee.ran"
+assert_file_not_exists "real-exec-fail: no stale failure marker" "$SPECTER_DIR/.hotinstall_failed"
+_ui="$(cat "$UI_LOG")"
+assert_contains "real-exec-fail: ui warns about apply failure" "$_ui" "WARNING: live-apply failed"
+assert_not_contains "real-exec-fail: ui does not promise no-reboot" "$_ui" "No need to reboot"
+
+done_testing

--- a/tests/test_hotinstall.sh
+++ b/tests/test_hotinstall.sh
@@ -121,31 +121,20 @@ specter_hot_install
 assert_file_eq "modid: myfork live updated" "$MODULES_BASE/myfork/module.prop" "$(printf 'id=myfork\nname=NewVersion\nversionCode=2\n')"
 assert_file_exists "modid: myfork executor ran" "$MODULES_BASE/myfork/hi.ran"
 
-# ---- real executor: src/hotinstall.sh invokes tee.sh + action.sh, streams to ui_print ----
-# Replace the stub hotinstall.sh with the REAL src/hotinstall.sh and stub its
-# siblings (features/tee.sh, action.sh, lib/scheduler.sh). This catches
-# regressions in the actual executor — e.g. "did we forget to call tee.sh?"
-# — that a stub-based test cannot.
-bootstrap
-source_libs
-_hi_setup
-rm -f "$STAGE/hotinstall.sh"
-cp "$REPO_ROOT/src/hotinstall.sh" "$STAGE/hotinstall.sh"
-chmod +x "$STAGE/hotinstall.sh"
-# Stub: features/tee.sh — writes a marker so we can prove it ran
-mkdir -p "$STAGE/features"
-printf '#!/bin/sh\necho tee_ok > "$SPECTER_DIR/tee.ran"\n' > "$STAGE/features/tee.sh"
-chmod +x "$STAGE/features/tee.sh"
-# Stub: action.sh — writes a marker; uses set -e-safe pattern (real action.sh)
-printf '#!/bin/sh\necho ACTION-OK\necho ran > "$SPECTER_DIR/act.ran"\nexit 0\n' > "$STAGE/action.sh"
-chmod +x "$STAGE/action.sh"
-# Stub: lib/scheduler.sh — exits immediately; sched loop never starts in tests
-mkdir -p "$STAGE/lib"
-printf '#!/bin/sh\nexit 0\n' > "$STAGE/lib/scheduler.sh"
-# Stub lib/common.sh needs to be available — the real common.sh sources more
-# libs. Use a minimal stub so we don't drag in detect/keystore/network etc. that
-# rely on Android runtime. Plus a stub log_i/log_w/log_e/log_d/log_rotate.
-cat > "$STAGE/lib/common.sh" << 'COMMON_EOF'
+# Helpers for real-executor tests: use the actual src/hotinstall.sh, but stub
+# its siblings so the test runs without an Android runtime.
+_hi_setup_real_executor() {
+  bootstrap
+  source_libs
+  _hi_setup
+  rm -f "$STAGE/hotinstall.sh"
+  cp "$REPO_ROOT/src/hotinstall.sh" "$STAGE/hotinstall.sh"
+  chmod +x "$STAGE/hotinstall.sh"
+  mkdir -p "$STAGE/features" "$STAGE/lib"
+  printf '#!/bin/sh\necho tee_ok > "$SPECTER_DIR/tee.ran"\n' > "$STAGE/features/tee.sh"
+  chmod +x "$STAGE/features/tee.sh"
+  printf '#!/bin/sh\nexit 0\n' > "$STAGE/lib/scheduler.sh"
+  cat > "$STAGE/lib/common.sh" << 'COMMON_EOF'
 log_d() { :; }
 log_i() { echo "$2"; }
 log_w() { echo "Warning: $2"; }
@@ -154,9 +143,15 @@ log_rotate() { :; }
 cfg_get() { echo "${2:-}"; }
 ensure_dir() { mkdir -p "$1" 2>/dev/null; }
 COMMON_EOF
-# Pre-seed the scheduler pid file so the kill path runs (proves it tolerates
-# a missing process: kill on a non-existent pid just fails silently).
-echo "99999" > "$SPECTER_DIR/scheduler.pid"
+  # Pre-seed the scheduler pid file so the kill path runs (proves it tolerates
+  # a missing process: kill on a non-existent pid just fails silently).
+  echo "99999" > "$SPECTER_DIR/scheduler.pid"
+}
+
+# ---- real executor: src/hotinstall.sh invokes tee.sh + action.sh, streams to ui_print ----
+_hi_setup_real_executor
+printf '#!/bin/sh\necho ACTION-OK\necho ran > "$SPECTER_DIR/act.ran"\nexit 0\n' > "$STAGE/action.sh"
+chmod +x "$STAGE/action.sh"
 specter_hot_install
 assert_file_exists "real-exec: tee.sh ran (TEE cache refresh)" "$SPECTER_DIR/tee.ran"
 assert_file_exists "real-exec: action.sh ran" "$SPECTER_DIR/act.ran"
@@ -169,27 +164,9 @@ assert_contains "real-exec: action.sh child output streamed (ACTION-OK)" "$_ui" 
 assert_contains "real-exec: done line streamed" "$_ui" "Hot-install live-apply done"
 
 # ---- real executor: action.sh failure writes status marker, hot install warns ----
-bootstrap
-source_libs
-_hi_setup
-rm -f "$STAGE/hotinstall.sh"
-cp "$REPO_ROOT/src/hotinstall.sh" "$STAGE/hotinstall.sh"
-chmod +x "$STAGE/hotinstall.sh"
-mkdir -p "$STAGE/features" "$STAGE/lib"
-printf '#!/bin/sh\necho tee_ok > "$SPECTER_DIR/tee.ran"\n' > "$STAGE/features/tee.sh"
-chmod +x "$STAGE/features/tee.sh"
+_hi_setup_real_executor
 printf '#!/bin/sh\necho ACTION-FAIL\nexit 7\n' > "$STAGE/action.sh"
 chmod +x "$STAGE/action.sh"
-printf '#!/bin/sh\nexit 0\n' > "$STAGE/lib/scheduler.sh"
-cat > "$STAGE/lib/common.sh" << 'COMMON_EOF'
-log_d() { :; }
-log_i() { echo "$2"; }
-log_w() { echo "Warning: $2"; }
-log_e() { echo "Error: $2" >&2; }
-log_rotate() { :; }
-cfg_get() { echo "${2:-}"; }
-ensure_dir() { mkdir -p "$1" 2>/dev/null; }
-COMMON_EOF
 specter_hot_install
 assert_file_exists "real-exec-fail: tee.sh still ran" "$SPECTER_DIR/tee.ran"
 assert_file_not_exists "real-exec-fail: no stale failure marker" "$SPECTER_DIR/.hotinstall_failed"


### PR DESCRIPTION
Adds KernelSU-only hot install: during `customize.sh`, move the staged module dir into the live dir and re-run the on-demand integrity pipeline so new spoofing takes effect without a reboot.

What changed:
- `lib/hotinstall.sh`: gated dir move, `.first_boot_pending` cleanup, KSU `ensure_file_exists` dance, and `ui_print` streaming of the executor.
- `hotinstall.sh`: TEE cache refresh, old scheduler kill + relaunch, then `action.sh`. Streams all output back to the parent `customize.sh` `ui_print` so the install doesn't look stalled.
- `customize.sh`: source the lib and invoke the function; suppress the legacy "next reboot" message when hot install ran.
- `tee.sh`: skip the boot-time `sleep 5` when `SPECTER_HOT_INSTALL=1`.

Scope limits:
- KernelSU family only (KernelSU, KernelSU-Next, SukiSU-Ultra). APatch is unverified upstream; Magisk binds modules at boot via magic-mount, so a live dir move is a no-op there.
- Live-apply runs `action.sh`, not `service.sh`. Boot-only prop/mount features (`rom_fingerprint`, `boot_state_props`, `vbmeta`, `boot_hash`) are skipped by boundary — they set state only read during early boot.