### PR TITLE
fix(keybox): prefer active over softbanned when fetching

### DIFF
--- a/src/features/keybox.sh
+++ b/src/features/keybox.sh
@@ -84,26 +84,17 @@ if [ -z "$_history" ]; then
 else
   if [ "$_provider" = "auto" ]; then
     _wk_raw=$(echo "$_history" | grep -o '"workingEntries":\[[^]]*\]' | sed 's/"workingEntries":\[//' | sed 's/\]$//')
-    if [ -n "$_wk_raw" ]; then
-      _wk_count=$(echo "$_wk_raw" | grep -o '{"source":"[^"]*","version":"[^"]*","text":"[^"]*"}' | wc -l)
-      if [ "$_wk_count" -gt 0 ]; then
-        _rand_hex=$(hexdump -n 4 -e '4/4 "%08X"' /dev/urandom 2>/dev/null) && _random_index=$(( 0x${_rand_hex} % _wk_count )) || _random_index=$(( $$ % _wk_count ))
-        _wk_entry=$(echo "$_wk_raw" | grep -o '{"source":"[^"]*","version":"[^"]*","text":"[^"]*"}' | sed -n "$((_random_index + 1))p")
-        _DL_SOURCE=$(echo "$_wk_entry" | sed 's/.*"source":"\([^"]*\)".*/\1/')
-        _DL_VER=$(echo "$_wk_entry" | sed 's/.*"version":"\([^"]*\)".*/\1/')
-        _DL_TEXT=$(echo "$_wk_entry" | sed 's/.*"text":"\([^"]*\)".*/\1/')
-        [ -z "$_DL_TEXT" ] && _DL_TEXT="$_DL_VER"
-        log_i "KEYBOX" "Randomly selected: $_DL_SOURCE $_DL_TEXT (entry $_random_index of $_wk_count)"
-      else
-        _working_source=$(echo "$_history" | grep -o '"working":{[^}]*"source":"[^"]*"' | sed 's/.*"source":"\([^"]*\)".*/\1/')
-        _working_version=$(echo "$_history" | grep -o '"working":{[^}]*"version":"[^"]*"' | sed 's/.*"version":"\([^"]*\)".*/\1/')
-        [ -n "$_working_source" ] && [ -n "$_working_version" ] || die "No working keybox available (all revoked?)"
-        _DL_SOURCE="$_working_source"
-        _DL_VER="$_working_version"
-        _DL_TEXT=$(echo "$_history" | grep -o '"source":"'"$_DL_SOURCE"'"[^}]*"version":"'"$_DL_VER"'"[^}]*"text":"[^"]*"' | sed 's/.*"text":"\([^"]*\)".*/\1/')
-        [ -z "$_DL_TEXT" ] && _DL_TEXT="$_DL_VER"
-        log_i "KEYBOX" "Auto-selected: $_DL_SOURCE $_DL_TEXT"
-      fi
+    _wk_pool=$(echo "$_wk_raw" | grep -o '{"source":"[^"]*","version":"[^"]*","text":"[^"]*"}' | keybox_prefer_active "$_history")
+    _wk_count=$(printf '%s' "$_wk_pool" | grep -c '{"source":' || true)
+    [ -z "$_wk_count" ] && _wk_count=0
+    if [ "$_wk_count" -gt 0 ]; then
+      _rand_hex=$(hexdump -n 4 -e '4/4 "%08X"' /dev/urandom 2>/dev/null) && _random_index=$(( 0x${_rand_hex} % _wk_count )) || _random_index=$(( $$ % _wk_count ))
+      _wk_entry=$(printf '%s' "$_wk_pool" | grep -o '{"source":"[^"]*","version":"[^"]*","text":"[^"]*"}' | sed -n "$((_random_index + 1))p")
+      _DL_SOURCE=$(echo "$_wk_entry" | sed 's/.*"source":"\([^"]*\)".*/\1/')
+      _DL_VER=$(echo "$_wk_entry" | sed 's/.*"version":"\([^"]*\)".*/\1/')
+      _DL_TEXT=$(echo "$_wk_entry" | sed 's/.*"text":"\([^"]*\)".*/\1/')
+      [ -z "$_DL_TEXT" ] && _DL_TEXT="$_DL_VER"
+      log_i "KEYBOX" "Randomly selected: $_DL_SOURCE $_DL_TEXT (entry $_random_index of $_wk_count)"
     else
       _working_source=$(echo "$_history" | grep -o '"working":{[^}]*"source":"[^"]*"' | sed 's/.*"source":"\([^"]*\)".*/\1/')
       _working_version=$(echo "$_history" | grep -o '"working":{[^}]*"version":"[^"]*"' | sed 's/.*"version":"\([^"]*\)".*/\1/')
@@ -116,7 +107,7 @@ else
     fi
   else
     _DL_SOURCE="$_provider"
-    _DL_VER=$(echo "$_history" | grep -o '"source":"'"$_provider"'"[^}]*"version":"[^"]*"' | sed 's/.*"version":"\([^"]*\)".*/\1/' | sort -rn | head -1)
+    _DL_VER=$(keybox_latest_for_provider "$_history" "$_provider")
     [ -n "$_DL_VER" ] || die "No versions found for provider '$_provider'"
     _DL_TEXT=$(echo "$_history" | grep -o '"source":"'"$_DL_SOURCE"'"[^}]*"version":"'"$_DL_VER"'"[^}]*"text":"[^"]*"' | sed 's/.*"text":"\([^"]*\)".*/\1/')
     [ -z "$_DL_TEXT" ] && _DL_TEXT="$_DL_VER"

--- a/src/lib/keybox.sh
+++ b/src/lib/keybox.sh
@@ -81,3 +81,45 @@ find_kmInstallKeybox() {
   echo "${_fk_bin:-}"
   unset _fk_abi _fk_lib_dir _fk_bin _fk_dir
 }
+
+# True if catalog entry for SOURCE/VERSION is softbanned.
+keybox_is_softbanned() {
+  echo "$1" | grep -o '"entries":\[[^]]*\]' | grep -o '{[^}]*"source":"'"$2"'"[^}]*"version":"'"$3"'"[^}]*}' | head -1 | grep -q '"softbanned":true'
+}
+
+# Prefer active (non-softbanned) candidates. stdin: one JSON object per line
+# with source/version. $1 = full catalog JSON. stdout: preferred pool.
+keybox_prefer_active() {
+  _kpa_hist="$1"
+  _kpa_active=""
+  _kpa_soft=""
+  while IFS= read -r _kpa_entry || [ -n "$_kpa_entry" ]; do
+    [ -z "$_kpa_entry" ] && continue
+    _kpa_src=$(echo "$_kpa_entry" | sed 's/.*"source":"\([^"]*\)".*/\1/')
+    _kpa_ver=$(echo "$_kpa_entry" | sed 's/.*"version":"\([^"]*\)".*/\1/')
+    if keybox_is_softbanned "$_kpa_hist" "$_kpa_src" "$_kpa_ver"; then
+      _kpa_soft="${_kpa_soft}${_kpa_entry}
+"
+    else
+      _kpa_active="${_kpa_active}${_kpa_entry}
+"
+    fi
+  done
+  if [ -n "$_kpa_active" ]; then
+    printf '%s' "$_kpa_active"
+  else
+    printf '%s' "$_kpa_soft"
+  fi
+  unset _kpa_hist _kpa_active _kpa_soft _kpa_entry _kpa_src _kpa_ver
+}
+
+# Latest version for PROVIDER from catalog, preferring non-softbanned.
+keybox_latest_for_provider() {
+  _klp_hist="$1"
+  _klp_prov="$2"
+  _klp_entries=$(echo "$_klp_hist" | grep -o '"entries":\[[^]]*\]' | grep -o '{[^}]*"source":"'"$_klp_prov"'"[^}]*}')
+  _klp_ver=$(printf '%s\n' "$_klp_entries" | grep -v '"softbanned":true' | sed 's/.*"version":"\([^"]*\)".*/\1/' | sort -rn | head -1)
+  [ -z "$_klp_ver" ] && _klp_ver=$(printf '%s\n' "$_klp_entries" | grep '"softbanned":true' | sed 's/.*"version":"\([^"]*\)".*/\1/' | sort -rn | head -1)
+  echo "$_klp_ver"
+  unset _klp_hist _klp_prov _klp_entries _klp_ver
+}

--- a/tests/test_keybox_select.sh
+++ b/tests/test_keybox_select.sh
@@ -1,0 +1,41 @@
+plan "keybox selection prefers active over softbanned"
+
+bootstrap
+source_libs
+
+_CATALOG='{"entries":[{"source":"droidwin","version":"1","text":"v1","serial":"12345","revoked":false,"softbanned":false},{"source":"droidwin","version":"2","text":"v2","serial":"67890","revoked":false,"softbanned":true},{"source":"yuri","version":"8","text":"v8","serial":"11111","revoked":false,"softbanned":true}],"working":{"source":"droidwin","version":"1"},"workingEntries":[{"source":"droidwin","version":"1","text":"v1"},{"source":"droidwin","version":"2","text":"v2"},{"source":"yuri","version":"8","text":"v8"}]}'
+
+# --- keybox_is_softbanned ---
+keybox_is_softbanned "$_CATALOG" "droidwin" "2"
+_rc=$?
+assert_eq "is_softbanned: droidwin/2" "0" "$_rc"
+
+keybox_is_softbanned "$_CATALOG" "droidwin" "1"
+_rc=$?
+assert_eq "is_softbanned: droidwin/1 active" "1" "$_rc"
+
+# --- keybox_prefer_active: mix of active + softbanned -> only active ---
+_wk='{"source":"droidwin","version":"1","text":"v1"}
+{"source":"droidwin","version":"2","text":"v2"}
+{"source":"yuri","version":"8","text":"v8"}'
+_pool=$(printf '%s\n' "$_wk" | keybox_prefer_active "$_CATALOG")
+assert_contains "prefer_active: keeps active" "$_pool" '"version":"1"'
+assert_not_contains "prefer_active: drops softbanned droidwin/2" "$_pool" '"version":"2"'
+assert_not_contains "prefer_active: drops softbanned yuri/8" "$_pool" '"version":"8"'
+
+# --- keybox_prefer_active: only softbanned -> softbanned ok ---
+_wk_soft='{"source":"droidwin","version":"2","text":"v2"}
+{"source":"yuri","version":"8","text":"v8"}'
+_pool_soft=$(printf '%s\n' "$_wk_soft" | keybox_prefer_active "$_CATALOG")
+assert_contains "prefer_active fallback: softbanned kept" "$_pool_soft" '"version":"2"'
+assert_contains "prefer_active fallback: both softbanned kept" "$_pool_soft" '"version":"8"'
+
+# --- keybox_latest_for_provider: skips softbanned latest ---
+_ver=$(keybox_latest_for_provider "$_CATALOG" "droidwin")
+assert_eq "latest_for_provider: prefers active over newer softbanned" "1" "$_ver"
+
+# --- keybox_latest_for_provider: softbanned-only provider ---
+_ver_yuri=$(keybox_latest_for_provider "$_CATALOG" "yuri")
+assert_eq "latest_for_provider: softbanned when no active" "8" "$_ver_yuri"
+
+done_testing


### PR DESCRIPTION
Keybox fetch picked randomly from `workingEntries` (auto) or the highest version for a provider without checking `softbanned`. A softbanned box could win over an active one — e.g. provider latest picking Lei Jun v3 over v4.

## Changes
- Auto: filter `workingEntries` through catalog `entries` softbanned flags; random-pick from active only, fall back to softbanned when nothing active remains.
- Provider: latest non-softbanned version first; softbanned only if that's all there is.
- Softbanned lookups scoped to the `entries` array so `workingEntries` stubs without the flag aren't treated as active.
- Shell tests in `test_keybox_select.sh`.

## Tested
- `bash tests/run.sh keybox_select` — 9 pass
- Checked against live rawbin catalog: selects `@Xiaomi_Lei_Jun` v4 (active) over v3 (softbanned)