### PR TITLE
Fixes and UI Improvements: Dialogs, Navbar, and Concurrency Guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Specter is a complete rewrite of what I originally built as Yurikey.
 
 ## Quick start
 
-1. Install [Tricky Store](https://github.com/5ec1cff/TrickyStore/releases/latest) or a fork
-2. Install any PIF fork
+1. Install [Tricky Store](https://github.com/5ec1cff/TrickyStore/releases/latest) /
+   [TEESimulator](https://github.com/JingMatrix/TEESimulator/releases/latest) /
+   [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS/releases/latest)
+   (Specter auto-installs TEESimulator-RS if none found — skip if using OhMyKeymint)
+2. Install [Play Integrity Inject](https://github.com/KOWX712/PlayIntegrityFix/releases/latest)
+   or [Play Integrity Fork](https://github.com/osm0sis/PlayIntegrityFork/releases/latest)
 3. Install Specter via Magisk / KernelSU / APatch
 4. Reboot. First-boot runs backup, target, security patch, keybox.
 5. Open the WebUI
@@ -55,8 +59,13 @@ Specter is a complete rewrite of what I originally built as Yurikey.
 ## Requirements
 
 - Root access (Magisk / KernelSU / APatch)
-- Tricky Store or fork
-- Play Integrity Fix or fork (recommended)
+- [Tricky Store](https://github.com/5ec1cff/TrickyStore/releases/latest) /
+  [TEESimulator](https://github.com/JingMatrix/TEESimulator/releases/latest) /
+  [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS/releases/latest) /
+  or OhMyKeymint
+  (Specter auto-installs TEESimulator-RS if none detected)
+- [Play Integrity Inject](https://github.com/KOWX712/PlayIntegrityFix/releases/latest)
+  or [Play Integrity Fork](https://github.com/osm0sis/PlayIntegrityFork/releases/latest)
 
 ## Build
 

--- a/inline-css.cjs
+++ b/inline-css.cjs
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const assets = fs.readdirSync('Module/webroot/assets');
-const cssFile = assets.find(f => /^index-[a-zA-Z0-9-]+\.css$/.test(f));
+const cssFile = assets.find(f => /^index-[a-zA-Z0-9_-]+\.css$/.test(f));
 if (!cssFile) { console.warn('No index CSS found in', assets); process.exit(0); }
 const css = fs.readFileSync(path.join('Module/webroot/assets', cssFile), 'utf-8');
 let html = fs.readFileSync('Module/webroot/index.html', 'utf-8');

--- a/src/action.sh
+++ b/src/action.sh
@@ -116,4 +116,5 @@ if [ "$_first_boot" = "0" ]; then
   printf '{"script":"action.sh","output":"Full integrity pipeline completed","time":"%s","code":0}\n' "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" >> "$SPECTER_DIR/log/history.jsonl"
 fi
 
+echo "Action has ended, please exit"
 exit 0

--- a/src/webroot/common/device-info.sh
+++ b/src/webroot/common/device-info.sh
@@ -42,6 +42,7 @@ if [ -f "$TEE_STATUS" ]; then
 fi
 if [ -f "$TEE_TIER" ]; then
   _tee_tier=$(cat "$TEE_TIER" | tr -d ' \n')
+  [ -z "$_tee_tier" ] && _tee_tier="null"
 else
   _tee_tier="null"
 fi

--- a/src/webroot/css/app.css
+++ b/src/webroot/css/app.css
@@ -14,8 +14,22 @@ body {
   user-select: none;
   -webkit-touch-callout: none;
 }
-body:has(md-dialog[open]) {
+body.dialog-open {
   overflow: hidden;
+}
+
+.dialog-blur-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1001;
+  background: rgba(0, 0, 0, 0.32);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+body.dialog-open .dialog-blur-backdrop {
+  opacity: 1;
 }
 
 input, textarea, [contenteditable="true"] {
@@ -909,12 +923,6 @@ md-divider.settings-divider {
 }
 
 /* --- Floating Navigation Bar --- */
-
-body:has(md-dialog[open]) .nav-bar,
-body:has(.ta-overlay--open) .nav-bar {
-  display: none !important;
-}
-
 @media (pointer: coarse), (max-height: 600px) {
   body:has(input:focus, textarea:focus, [contenteditable="true"]:focus, md-outlined-text-field:focus-within) .nav-bar {
     display: none !important;

--- a/src/webroot/index.html
+++ b/src/webroot/index.html
@@ -594,7 +594,8 @@
 
   </div>
 
-  <md-dialog id="progress-dialog">
+  <div id="dialog-blur-backdrop" class="dialog-blur-backdrop"></div>
+  <md-dialog id="progress-dialog" scrim-click-action="" escape-action="">
     <div slot="content" class="simple-progress">
       <md-circular-progress indeterminate></md-circular-progress>
       <p class="md-typescale-body-medium" id="progress-label"></p>

--- a/src/webroot/js/app.ts
+++ b/src/webroot/js/app.ts
@@ -89,6 +89,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   import('./font.js').then(m => m.initFonts()).catch(() => {});
 
   wireConflictToggles().catch(() => {});
+
+  // Watch for dialog open/close to toggle blur class
+  const dialogObserver = new MutationObserver(() => {
+    document.body.classList.toggle('dialog-open', !!document.querySelector('md-dialog[open]'));
+  });
+  dialogObserver.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['open'] });
+  document.getElementById('progress-dialog')?.addEventListener('cancel', (e: Event) => e.preventDefault());
 });
 
 async function wireConflictToggles() {

--- a/src/webroot/js/autokeybox-ui.ts
+++ b/src/webroot/js/autokeybox-ui.ts
@@ -51,11 +51,16 @@ export function openAutokeyboxDialog() {
     cancelBtn.addEventListener('click', () => dialog.close());
 
     saveBtn.addEventListener('click', () => {
-      const num = parseInt(intervalInput.value || String(DEFAULT_HOURS), 10);
-      const seconds = String(Math.max(1, num) * HOURS_TO_SECONDS);
-      cfgSet('autokeybox_interval', seconds);
-      showToast(t('autokeybox_saved', 'Auto Keybox settings saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
-      dialog.close();
+      (saveBtn as HTMLButtonElement).disabled = true;
+      try {
+        const num = parseInt(intervalInput.value || String(DEFAULT_HOURS), 10);
+        const seconds = String(Math.max(1, num) * HOURS_TO_SECONDS);
+        cfgSet('autokeybox_interval', seconds);
+        showToast(t('autokeybox_saved', 'Auto Keybox settings saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
+        dialog.close();
+      } finally {
+        (saveBtn as HTMLButtonElement).disabled = false;
+      }
     });
 
     dialog.show();

--- a/src/webroot/js/autopif-ui.ts
+++ b/src/webroot/js/autopif-ui.ts
@@ -51,11 +51,16 @@ export function openAutopifDialog() {
     cancelBtn.addEventListener('click', () => dialog.close());
 
     saveBtn.addEventListener('click', () => {
-      const num = parseInt(intervalInput.value || String(DEFAULT_HOURS), 10);
-      const seconds = String(Math.max(1, num) * HOURS_TO_SECONDS);
-      cfgSet('autopif_interval', seconds);
-      showToast(t('autopif_saved', 'Auto PIF settings saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
-      dialog.close();
+      (saveBtn as HTMLButtonElement).disabled = true;
+      try {
+        const num = parseInt(intervalInput.value || String(DEFAULT_HOURS), 10);
+        const seconds = String(Math.max(1, num) * HOURS_TO_SECONDS);
+        cfgSet('autopif_interval', seconds);
+        showToast(t('autopif_saved', 'Auto PIF settings saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
+        dialog.close();
+      } finally {
+        (saveBtn as HTMLButtonElement).disabled = false;
+      }
     });
 
     dialog.show();

--- a/src/webroot/js/boot-hash-ui.ts
+++ b/src/webroot/js/boot-hash-ui.ts
@@ -66,6 +66,10 @@ export function wireBootHash() {
 
     dialog.querySelector('#boot-hash-cancel')!.addEventListener('click', () => dialog.close());
     dialog.querySelector('#boot-hash-clear')!.addEventListener('click', async () => {
+      const blockClose = (e: Event) => e.preventDefault();
+      dialog.addEventListener('cancel', blockClose);
+      const btn = dialog.querySelector('#boot-hash-clear') as HTMLButtonElement;
+      btn.disabled = true;
       try {
         await exec(`rm -f ${hashPath}`);
         await exec(`sh ${shellEscape(moddir + '/refresh_desc.sh')}`);
@@ -73,16 +77,23 @@ export function wireBootHash() {
         dialog.close();
       } catch {
         showToast(t('simple_toast_error', 'Failed'), { icon: 'error', type: 'error', autoCloseDelay: 3000 });
+      } finally {
+        dialog.removeEventListener('cancel', blockClose);
+        btn.disabled = false;
       }
     });
 
     dialog.querySelector('#boot-hash-save')!.addEventListener('click', async () => {
-      const val = input!.value.trim();
-      if (val && !/^[a-f0-9]{64}$/.test(val)) {
-        showToast(t('boot_hash_invalid', 'Invalid hash (must be 64 hex characters)'), { icon: 'error', type: 'error', autoCloseDelay: 3000 });
-        return;
-      }
+      const blockClose = (e: Event) => e.preventDefault();
+      dialog.addEventListener('cancel', blockClose);
+      const btn = dialog.querySelector('#boot-hash-save') as HTMLButtonElement;
+      btn.disabled = true;
       try {
+        const val = input!.value.trim();
+        if (val && !/^[a-f0-9]{64}$/.test(val)) {
+          showToast(t('boot_hash_invalid', 'Invalid hash (must be 64 hex characters)'), { icon: 'error', type: 'error', autoCloseDelay: 3000 });
+          return;
+        }
         if (val) {
           await exec(`mkdir -p ${shellEscape(cdir)} && printf '%s' ${shellEscape(val)} > ${hashPath}`);
           await exec(`su -c "resetprop -n ro.boot.vbmeta.digest ${shellEscape(val)}" 2>/dev/null || true`);
@@ -94,6 +105,9 @@ export function wireBootHash() {
         dialog.close();
       } catch {
         showToast(t('boot_hash_save_error', 'Failed to save'), { icon: 'error', type: 'error', autoCloseDelay: 4000 });
+      } finally {
+        dialog.removeEventListener('cancel', blockClose);
+        btn.disabled = false;
       }
     });
 

--- a/src/webroot/js/bridge.ts
+++ b/src/webroot/js/bridge.ts
@@ -135,10 +135,12 @@ export function spawnScript(scriptName: string, type = 'feature'): ChildProcess 
   if (typeof window.ksu?.spawn === 'function') {
     const globalName = genCallbackName();
     setGlobal(globalName, child);
-    (child as any).on('exit', () => deleteGlobal(globalName));
-    (child as any).on('error', () => deleteGlobal(globalName));
+    const cleanup = () => deleteGlobal(globalName);
+    const timer = setTimeout(cleanup, EXEC_TIMEOUT_MS);
+    (child as any).on('exit', () => { clearTimeout(timer); cleanup(); });
+    (child as any).on('error', () => { clearTimeout(timer); cleanup(); });
     try { window.ksu.spawn('sh', JSON.stringify([scriptPath]), '{}', globalName); }
-    catch (e) { deleteGlobal(globalName); setTimeout(() => (child as any).emit('error', e)); }
+    catch (e) { clearTimeout(timer); cleanup(); setTimeout(() => (child as any).emit('error', e)); }
   } else {
     const cmd = `sh ${shellEscape(scriptPath)}`;
     let timedOut = false;

--- a/src/webroot/js/device.ts
+++ b/src/webroot/js/device.ts
@@ -46,7 +46,7 @@ function applyKeyboxStatus(data: KeyboxInfoJson) {
   const versionEl = document.getElementById('keybox-version')!;
   const statusEl = document.getElementById('keybox-status')!;
   const badgeEl = document.getElementById('kb-version-badge')!;
-  if (!source || !statusEl || !badgeEl) return;
+  if (!source || !versionEl || !statusEl || !badgeEl) return;
 
   if (!data.installed) {
     source.textContent = getTranslation('device_not_installed') || 'Not Installed';

--- a/src/webroot/js/i18n.ts
+++ b/src/webroot/js/i18n.ts
@@ -52,7 +52,7 @@ function applyTranslations() {
       if (el.hasAttribute('aria-label')) el.setAttribute('aria-label', val);
       continue;
     }
-    if (val.includes('<')) { el.innerHTML = val; } else { el.textContent = val; }
+    el.textContent = val;
   }
   for (const el of document.querySelectorAll('[data-i18n-aria]')) {
     const val = currentStrings[(el as HTMLElement).dataset.i18nAria!] || fallbackStrings[(el as HTMLElement).dataset.i18nAria!];

--- a/src/webroot/js/keybox-ui.ts
+++ b/src/webroot/js/keybox-ui.ts
@@ -173,55 +173,61 @@ export async function openCustomKeyboxDialog() {
   });
 
   applyBtn!.addEventListener('click', async () => {
-    const moddir = getModuleDir();
-    const text = urlInput.value.trim();
+    const blockClose = (e: Event) => e.preventDefault();
+    dialog.addEventListener('cancel', blockClose);
+    try {
+      const moddir = getModuleDir();
+      const text = urlInput.value.trim();
 
-    if (!text) {
-      showToast(t('toast_enter_url', 'Enter a URL or device path'), { icon: 'error', type: 'error', autoCloseDelay: 2500 });
-      return;
-    }
+      if (!text) {
+        showToast(t('toast_enter_url', 'Enter a URL or device path'), { icon: 'error', type: 'error', autoCloseDelay: 2500 });
+        return;
+      }
 
-    const privateChoice = await new Promise<boolean>(resolve => {
-      const pd = document.createElement('md-dialog');
-      pd.className = 'private-dialog';
-      pd.innerHTML = `
-        <div slot="headline">${t('custom_kb_title', 'Custom Keybox')}</div>
-        <div slot="content">
-          <p class="private-dialog-msg">${t('custom_keybox_private_ask', 'Is this a private keybox?')}</p>
-        </div>
-        <div slot="actions">
-          <md-text-button id="kb-pri-no" value="no">${t('custom_kb_no', 'No')}</md-text-button>
-          <md-text-button id="kb-pri-yes" value="yes">${t('custom_kb_yes', 'Yes')}</md-text-button>
-        </div>
-      `;
-      document.body.appendChild(pd);
-      pd.querySelector('#kb-pri-no')!.addEventListener('click', () => { pd.close(); resolve(false); });
-      pd.querySelector('#kb-pri-yes')!.addEventListener('click', () => { pd.close(); resolve(true); });
-      pd.addEventListener('close', () => document.body.removeChild(pd));
-      pd.show();
-    });
+      const privateChoice = await new Promise<boolean>(resolve => {
+        const pd = document.createElement('md-dialog');
+        pd.className = 'private-dialog';
+        pd.innerHTML = `
+          <div slot="headline">${t('custom_kb_title', 'Custom Keybox')}</div>
+          <div slot="content">
+            <p class="private-dialog-msg">${t('custom_keybox_private_ask', 'Is this a private keybox?')}</p>
+          </div>
+          <div slot="actions">
+            <md-text-button id="kb-pri-no" value="no">${t('custom_kb_no', 'No')}</md-text-button>
+            <md-text-button id="kb-pri-yes" value="yes">${t('custom_kb_yes', 'Yes')}</md-text-button>
+          </div>
+        `;
+        document.body.appendChild(pd);
+        pd.querySelector('#kb-pri-no')!.addEventListener('click', () => { pd.close(); resolve(false); });
+        pd.querySelector('#kb-pri-yes')!.addEventListener('click', () => { pd.close(); resolve(true); });
+        pd.addEventListener('close', () => document.body.removeChild(pd));
+        pd.show();
+      });
 
-    if (privateChoice) {
-      cfgSet('keybox_private', 'true');
-    } else {
-      cfgSet('keybox_private', '');
+      if (privateChoice) {
+        cfgSet('keybox_private', 'true');
+      } else {
+        cfgSet('keybox_private', '');
+      }
+      if (text.startsWith('http://') || text.startsWith('https://')) {
+        cfgSet('keybox_custom_type', 'url');
+      } else {
+        cfgSet('keybox_custom_type', 'path');
+      }
+      cfgSet('keybox_custom_value', text);
+      const result: any = await exec(`sh ${shellEscape(moddir + '/features/keybox.sh')}`);
+      if (result.code === 0) {
+        showToast(t('custom_kb_installed', 'Custom keybox installed'), { icon: 'check_circle', type: 'success', autoCloseDelay: 3000 });
+        await exec(`sh ${shellEscape(moddir + '/features/keybox_info.sh')}`).catch(() => {});
+        await exec(`sh ${shellEscape(moddir + '/refresh_desc.sh')}`).catch(() => {});
+        await refreshKeyboxStatus();
+      } else {
+        showToast(t('custom_kb_install_failed', 'Install failed'), { icon: 'error', type: 'error', autoCloseDelay: 5000 });
+      }
+      dialog.close();
+    } finally {
+      dialog.removeEventListener('cancel', blockClose);
     }
-    if (text.startsWith('http://') || text.startsWith('https://')) {
-      cfgSet('keybox_custom_type', 'url');
-    } else {
-      cfgSet('keybox_custom_type', 'path');
-    }
-    cfgSet('keybox_custom_value', text);
-    const result: any = await exec(`sh ${shellEscape(moddir + '/features/keybox.sh')}`);
-    if (result.code === 0) {
-      showToast(t('custom_kb_installed', 'Custom keybox installed'), { icon: 'check_circle', type: 'success', autoCloseDelay: 3000 });
-      await exec(`sh ${shellEscape(moddir + '/features/keybox_info.sh')}`).catch(() => {});
-      await exec(`sh ${shellEscape(moddir + '/refresh_desc.sh')}`).catch(() => {});
-      await refreshKeyboxStatus();
-    } else {
-      showToast(t('custom_kb_install_failed', 'Install failed'), { icon: 'error', type: 'error', autoCloseDelay: 5000 });
-    }
-    dialog.close();
   });
 
   dialog.addEventListener('close', () => {

--- a/src/webroot/js/security-patch-ui.ts
+++ b/src/webroot/js/security-patch-ui.ts
@@ -46,41 +46,53 @@ export function wireSecurityPatch() {
     if (input) input.value = current || defaultDate;
 
     dialog.querySelector('#sp-fetch')!.addEventListener('click', async () => {
-      const fetchingToast = showToast(t('sp_fetching', 'Fetching latest security patch...'), { icon: 'info', type: 'info', autoCloseDelay: 10000 });
+      const blockClose = (e: Event) => e.preventDefault();
+      dialog.addEventListener('cancel', blockClose);
       try {
-        const { stdout } = await exec(`sh ${scriptPath} --fetch 2>/dev/null || echo ""`);
-        closeToast(fetchingToast);
-        const date = stdout.trim();
-        if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
-          input!.value = date;
-          showToast(t('sp_fetched', 'Latest security patch fetched'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
-        } else {
+        const fetchingToast = showToast(t('sp_fetching', 'Fetching latest security patch...'), { icon: 'info', type: 'info', autoCloseDelay: 10000 });
+        try {
+          const { stdout } = await exec(`sh ${scriptPath} --fetch 2>/dev/null || echo ""`);
+          closeToast(fetchingToast);
+          const date = stdout.trim();
+          if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+            input!.value = date;
+            showToast(t('sp_fetched', 'Latest security patch fetched'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
+          } else {
+            showToast(t('simple_toast_error', 'Failed'), { icon: 'error', type: 'error', autoCloseDelay: 3000 });
+          }
+        } catch {
+          closeToast(fetchingToast);
           showToast(t('simple_toast_error', 'Failed'), { icon: 'error', type: 'error', autoCloseDelay: 3000 });
         }
-      } catch {
-        closeToast(fetchingToast);
-        showToast(t('simple_toast_error', 'Failed'), { icon: 'error', type: 'error', autoCloseDelay: 3000 });
+      } finally {
+        dialog.removeEventListener('cancel', blockClose);
       }
     });
 
     dialog.querySelector('#sp-cancel')!.addEventListener('click', () => dialog.close());
     dialog.querySelector('#sp-save')!.addEventListener('click', async () => {
-      const val = input!.value.trim();
-      if (!val || !/^\d{4}-\d{2}-\d{2}$/.test(val)) {
-        showToast(t('sp_invalid_date', 'Invalid date format (use YYYY-MM-DD)'), { icon: 'error', type: 'error', autoCloseDelay: 3000 });
-        return;
-      }
+      const blockClose = (e: Event) => e.preventDefault();
+      dialog.addEventListener('cancel', blockClose);
       try {
-        const { code, stderr } = await exec(`sh ${scriptPath} --set ${shellEscape(val)}`);
-        if (code !== 0) {
-          showToast(t('sp_save_error', stderr.trim() || 'Failed to save'), { icon: 'error', type: 'error', autoCloseDelay: 4000 });
+        const val = input!.value.trim();
+        if (!val || !/^\d{4}-\d{2}-\d{2}$/.test(val)) {
+          showToast(t('sp_invalid_date', 'Invalid date format (use YYYY-MM-DD)'), { icon: 'error', type: 'error', autoCloseDelay: 3000 });
           return;
         }
-        await exec(`sh ${shellEscape(moddir + '/refresh_desc.sh')}`);
-        showToast(t('sp_saved', 'Security patch date saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
-        dialog.close();
-      } catch {
-        showToast(t('sp_save_error', 'Failed to save'), { icon: 'error', type: 'error', autoCloseDelay: 4000 });
+        try {
+          const { code, stderr } = await exec(`sh ${scriptPath} --set ${shellEscape(val)}`);
+          if (code !== 0) {
+            showToast(t('sp_save_error', stderr.trim() || 'Failed to save'), { icon: 'error', type: 'error', autoCloseDelay: 4000 });
+            return;
+          }
+          await exec(`sh ${shellEscape(moddir + '/refresh_desc.sh')}`);
+          showToast(t('sp_saved', 'Security patch date saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
+          dialog.close();
+        } catch {
+          showToast(t('sp_save_error', 'Failed to save'), { icon: 'error', type: 'error', autoCloseDelay: 4000 });
+        }
+      } finally {
+        dialog.removeEventListener('cancel', blockClose);
       }
     });
 

--- a/src/webroot/js/target-apps.ts
+++ b/src/webroot/js/target-apps.ts
@@ -960,40 +960,47 @@ export async function openTargetAppsManager() {
   wireFilter('#ta-filter-selected', 'selected');
   wireFilter('#ta-filter-not-selected', 'not_selected');
 
-  overlay.querySelector('#ta-apply')!.addEventListener('click', async () => {
-    if (mode === 'blacklist') {
-      const bl = apps.filter(a => a.state === 'blacklisted').map(a => a.packageName).sort();
-      const content = bl.join('\n');
-      try {
-        const result = await exec(`printf '%s' ${shellEscape(content)} | base64 -w0`);
-        const b64 = result.stdout || '';
-        await exec(`mkdir -p ${specterDir()} && printf '%s' "${b64}" | base64 -d > ${specterDir()}/blacklist.txt`);
-        await exec(`mkdir -p ${specterDir()} && touch ${specterDir()}/blacklist_enabled`);
-        appendToOutput(`[TARGET] Wrote ${bl.length} entries to blacklist.txt`);
-        showToast(t('toast_blacklist_saved', 'Blacklist saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
-      } catch (e) {
-        appendToOutput(`[TARGET] Failed to save blacklist: ${e}`, true);
-      }
-      return;
-    }
-
-    const lines = apps
-      .filter(a => a.state !== 'unchecked')
-      .map(a => {
-        if (a.state === 'force') return a.packageName + '!';
-        if (a.state === 'conditional') return a.packageName + '?';
-        return a.packageName;
-      })
-      .sort();
-
-    const content = lines.join('\n');
+  const applyBtn = overlay.querySelector('#ta-apply') as HTMLButtonElement;
+  applyBtn.addEventListener('click', async () => {
+    if (applyBtn.disabled) return;
+    applyBtn.disabled = true;
     try {
-      await exec(`cat > ${TRICKY_DIR}/target.txt << 'TEOF'\n${content}\nTEOF`);
-      appendToOutput(`[TARGET] Wrote ${lines.length} entries to target.txt`);
-      showToast(t('ta_prompt_saved', 'Target list saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
-      await exec(`sh ${shellEscape(getModuleDir() + '/refresh_desc.sh')}`);
-    } catch (e) {
-      appendToOutput(`[TARGET] Failed to save target list: ${e}`, true);
+      if (mode === 'blacklist') {
+        const bl = apps.filter(a => a.state === 'blacklisted').map(a => a.packageName).sort();
+        const content = bl.join('\n');
+        try {
+          const result = await exec(`printf '%s' ${shellEscape(content)} | base64 -w0`);
+          const b64 = result.stdout || '';
+          await exec(`mkdir -p ${specterDir()} && printf '%s' "${b64}" | base64 -d > ${specterDir()}/blacklist.txt`);
+          await exec(`mkdir -p ${specterDir()} && touch ${specterDir()}/blacklist_enabled`);
+          appendToOutput(`[TARGET] Wrote ${bl.length} entries to blacklist.txt`);
+          showToast(t('toast_blacklist_saved', 'Blacklist saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
+        } catch (e) {
+          appendToOutput(`[TARGET] Failed to save blacklist: ${e}`, true);
+        }
+        return;
+      }
+
+      const lines = apps
+        .filter(a => a.state !== 'unchecked')
+        .map(a => {
+          if (a.state === 'force') return a.packageName + '!';
+          if (a.state === 'conditional') return a.packageName + '?';
+          return a.packageName;
+        })
+        .sort();
+
+      const content = lines.join('\n');
+      try {
+        await exec(`cat > ${TRICKY_DIR}/target.txt << 'TEOF'\n${content}\nTEOF`);
+        appendToOutput(`[TARGET] Wrote ${lines.length} entries to target.txt`);
+        showToast(t('ta_prompt_saved', 'Target list saved'), { icon: 'check_circle', type: 'success', autoCloseDelay: 2500 });
+        await exec(`sh ${shellEscape(getModuleDir() + '/refresh_desc.sh')}`);
+      } catch (e) {
+        appendToOutput(`[TARGET] Failed to save target list: ${e}`, true);
+      }
+    } finally {
+      applyBtn.disabled = false;
     }
   });
 

--- a/src/webroot/js/theme.ts
+++ b/src/webroot/js/theme.ts
@@ -214,9 +214,10 @@ async function extractMonetColor(): Promise<string | null> {
 
 function wireThemeControls() {
   const modeGroup = document.getElementById('theme-mode-group');
-  modeGroup?.addEventListener('segmented-button-set-selection', (e: Event) => {
+  if (!modeGroup) return;
+  modeGroup.addEventListener('segmented-button-set-selection', (e: Event) => {
     const idx = (e as CustomEvent).detail.index;
-    const btn = modeGroup!.querySelectorAll('md-outlined-segmented-button')[idx];
+    const btn = modeGroup.querySelectorAll('md-outlined-segmented-button')[idx];
     if (btn) applyMode(btn.getAttribute('value') || 'dark');
   });
 

--- a/src/webroot/js/toast.ts
+++ b/src/webroot/js/toast.ts
@@ -26,9 +26,12 @@ export function showToast(message: string, options: { action?: string; icon?: st
 }
 
 function close(toast: HTMLElement) {
+  if (toast.dataset.closing) return;
+  toast.dataset.closing = 'true';
   toast.classList.remove('md-toast--open');
-  toast.addEventListener('transitionend', () => toast.parentNode?.removeChild(toast), { once: true });
-  setTimeout(() => toast.parentNode?.removeChild(toast), 300);
+  const cleanup = () => toast.parentNode?.removeChild(toast);
+  toast.addEventListener('transitionend', cleanup, { once: true });
+  setTimeout(cleanup, 300);
 }
 
 export function closeToast(toast: HTMLElement) { close(toast); }

--- a/src/webroot/json/dev.json
+++ b/src/webroot/json/dev.json
@@ -7,11 +7,11 @@
     "avatar": "https://github.com/dpejoh.png"
   },
   {
-    "name": "myst-25",
-    "username": "myst-25",
+    "name": "myzanori",
+    "username": "myzanori",
     "role": "WebUI Contributor",
-    "github": "https://myst.website/",
-    "avatar": "https://github.com/myst-25.png"
+    "github": "https://github.com/myzanori",
+    "avatar": "https://github.com/myzanori.png"
   },
   {
     "name": "Burak",

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,5 +7,6 @@ export default defineConfig({
     outDir: '../../Module/webroot',
     emptyOutDir: true,
     target: 'es2019',
+    cssTarget: ['chrome105'],
   },
 })


### PR DESCRIPTION
1. Contributor profile fix
- Updated myzanori profile in dev.json (name, username, github URL, avatar URL).

2. Dialog blur -> dark overlay
- Replaced body:has(md-dialog[open]) with body.dialog-open in app.css.
- Replaced backdrop-filter with a dark background overlay (rgba) and z-index 1001 to properly cover the navbar.

3. Dialog open detection (JS)
- Added MutationObserver in app.ts to toggle body.dialog-open class dynamically.

4. Build fix - inline-css regex
- Fixed regex in inline-css.cjs to match CSS filenames with underscores.

5. Vite config
- Added cssTarget: ['chrome105'] to prevent Lightning CSS from stripping backdrop-filter.

6. High-priority bug fixes
- device.ts: Fixed missing versionEl null check.
- device-info.sh: Handled empty tee_tier to prevent invalid JSON.
- i18n.ts: Fixed innerHTML XSS vector.
- toast.ts: Fixed Toast race condition.
- theme.ts: Added modeGroup non-null assertion.
- bridge.ts: Fixed spawnScript global leak.

7. Action pipeline
- Added 'Action has ended, please exit' message before exit in action.sh.

8. Rapid-click guards
- Added concurrency guards to Apply, Save, and Clear buttons in autopif-ui.ts, autokeybox-ui.ts, and boot-hash-ui.ts.

9. App Targeting Apply - rapid-click guard
- Added if (applyBtn.disabled) return + disabled state management in target-apps.ts.

10. Dialog cancel prevention
- Enforced script execution blocking on dialog dismiss via scrim/escape in keybox-ui.ts, security-patch-ui.ts, boot-hash-ui.ts, and app.ts (progress dialog).

11. Navbar
- Removed navbar hiding on dialog/overlay in app.css, keeping only the mobile input-focus rule.