### PR TITLE
keystore: overwrite omk files in place, drop ksm_secure

### DIFF
--- a/src/features/restore_backups.sh
+++ b/src/features/restore_backups.sh
@@ -17,9 +17,12 @@ detect_keystore_manager
 _restored=0
 
 if [ -f "$BACKUP_DIR/keybox.xml.bak" ] && [ -n "$KSM_KEYBOX" ]; then
-  cp "$BACKUP_DIR/keybox.xml.bak" "$KSM_KEYBOX"
-  log_i "RESTORE" "Restored keybox.xml"
-  _restored=$((_restored + 1))
+  if ksm_install_keybox "$BACKUP_DIR/keybox.xml.bak" copy; then
+    log_i "RESTORE" "Restored keybox.xml"
+    _restored=$((_restored + 1))
+  else
+    log_e "RESTORE" "Failed to restore keybox.xml"
+  fi
 fi
 
 case "$KSM_FORMAT" in

--- a/src/lib/keystore.sh
+++ b/src/lib/keystore.sh
@@ -77,20 +77,11 @@ ksm_reload_full() {
   touch "$OMK_RESTART_DIR/restart.all" 2>/dev/null
 }
 
-# OMK's keymint/injector processes drop to uid 1017 (AID_KEYSTORE) and read
-# their files at mode 0600, so anything we write into the OMK data dir must be
-# owned by 1017 with a keystore-readable context — a plain mv/cp from
-# /data/local/tmp leaves it root-owned and unreadable to the daemon. No-op for
-# Tricky Store, whose files just live under /data/adb. Dirs pass mode 0770.
-ksm_secure() {
-  [ "$KSM" = "omk" ] || return 0
-  _kse_path="$1" _kse_mode="${2:-0600}"
-  [ -e "$_kse_path" ] || { unset _kse_path _kse_mode; return 0; }
-  chown 1017:1017 "$_kse_path" 2>/dev/null || true
-  chmod "$_kse_mode" "$_kse_path" 2>/dev/null || true
-  chcon u:object_r:keystore_data_file:s0 "$_kse_path" 2>/dev/null \
-    || restorecon "$_kse_path" 2>/dev/null || true
-  unset _kse_path _kse_mode
+_ksm_inplace_from() {
+  _kif_src="$1" _kif_dst="$2"
+  [ -f "$_kif_dst" ] || { unset _kif_src _kif_dst; return 1; }
+  cat "$_kif_src" > "$_kif_dst" || { unset _kif_src _kif_dst; return 1; }
+  unset _kif_src _kif_dst
 }
 
 _ksm_strip_suffix() {
@@ -147,10 +138,12 @@ ksm_commit_targets() {
         _kct_base=$(_ksm_strip_suffix "$_kct_line")
         [ -n "$_kct_base" ] && printf '%s\n' "$_kct_base" >> "$_kct_tmp"
       done < "$_kct_src"
-      _toml_write_scoop "$KSM_TARGETS" < "$_kct_tmp"
+      _toml_write_scoop "$KSM_TARGETS" < "$_kct_tmp" || {
+        rm -f "$_kct_tmp"
+        unset _kct_line _kct_base _kct_tmp _kct_src
+        return 1
+      }
       rm -f "$_kct_tmp"
-      ksm_secure "$KSM_DIR" 0770
-      ksm_secure "$KSM_TARGETS" 0600
       unset _kct_line _kct_base _kct_tmp
       ;;
     *)
@@ -183,9 +176,10 @@ ksm_set_security_patch() {
   _ksp_date="$1"
   case "$KSM_FORMAT" in
     toml)
-      _toml_set_trust_key "$KSM_SECURITY" "security_patch" "\"$_ksp_date\""
-      ksm_secure "$KSM_DIR" 0770
-      ksm_secure "$KSM_SECURITY" 0600
+      _toml_set_trust_key "$KSM_SECURITY" "security_patch" "\"$_ksp_date\"" || {
+        unset _ksp_date
+        return 1
+      }
       ;;
     *)
       _ksp_vendor=$(getprop ro.vendor.build.security_patch 2>/dev/null || echo "")
@@ -203,19 +197,26 @@ ksm_set_security_patch() {
   unset _ksp_date
 }
 
-# Installs a keybox file for the active manager. MODE "copy" preserves SRC
-# (e.g. a user-provided custom keybox); default "move" consumes it (e.g. a
-# decoded download temp file).
+# MODE "copy" keeps SRC; default "move" consumes it.
 ksm_install_keybox() {
   _kik_src="$1" _kik_mode="${2:-move}"
-  mkdir -p "$(dirname "$KSM_KEYBOX")" 2>/dev/null
-  if [ "$_kik_mode" = "copy" ]; then
-    cp "$_kik_src" "$KSM_KEYBOX" || { unset _kik_src _kik_mode; return 1; }
-  else
-    mv "$_kik_src" "$KSM_KEYBOX" || { unset _kik_src _kik_mode; return 1; }
-  fi
-  ksm_secure "$KSM_DIR" 0770
-  ksm_secure "$KSM_KEYBOX" 0600
+  case "$KSM" in
+    omk)
+      _ksm_inplace_from "$_kik_src" "$KSM_KEYBOX" || {
+        unset _kik_src _kik_mode
+        return 1
+      }
+      [ "$_kik_mode" = "copy" ] || rm -f "$_kik_src"
+      ;;
+    *)
+      mkdir -p "$(dirname "$KSM_KEYBOX")" 2>/dev/null
+      if [ "$_kik_mode" = "copy" ]; then
+        cp "$_kik_src" "$KSM_KEYBOX" || { unset _kik_src _kik_mode; return 1; }
+      else
+        mv "$_kik_src" "$KSM_KEYBOX" || { unset _kik_src _kik_mode; return 1; }
+      fi
+      ;;
+  esac
   unset _kik_src _kik_mode
 }
 
@@ -248,11 +249,11 @@ _toml_read_scoop() {
   ' "$_trs_file"
 }
 
-# Reads packages (one per line) from stdin and rewrites the `scoop` array
-# in FILE, preserving everything else. Idempotent: re-running with the same
-# input reproduces the same output byte-for-byte.
+# stdin packages → rewrite scoop in FILE; leave other keys alone.
 _toml_write_scoop() {
   _tws_file="$1"
+  [ -f "$_tws_file" ] || { unset _tws_file; return 1; }
+
   _tws_block="${_tws_file}.block.$$"
   {
     printf 'scoop = [\n'
@@ -265,7 +266,7 @@ _toml_write_scoop() {
 
   _tws_tmp="${_tws_file}.new.$$"
 
-  if [ -f "$_tws_file" ] && grep -Eq '^[ ]*scoop[ ]*=' "$_tws_file"; then
+  if grep -Eq '^[ ]*scoop[ ]*=' "$_tws_file"; then
     awk -v blockfile="$_tws_block" '
       function emit(   line) { while ((getline line < blockfile) > 0) print line; close(blockfile) }
       {
@@ -278,7 +279,7 @@ _toml_write_scoop() {
         print
       }
     ' "$_tws_file" > "$_tws_tmp"
-  elif [ -f "$_tws_file" ] && grep -Eq '^[ ]*\[' "$_tws_file"; then
+  elif grep -Eq '^[ ]*\[' "$_tws_file"; then
     awk -v blockfile="$_tws_block" '
       function emit(   line) { while ((getline line < blockfile) > 0) print line; close(blockfile) }
       BEGIN { injected = 0 }
@@ -289,25 +290,29 @@ _toml_write_scoop() {
     ' "$_tws_file" > "$_tws_tmp"
   else
     cat "$_tws_block" > "$_tws_tmp"
-    if [ -f "$_tws_file" ] && [ -s "$_tws_file" ]; then
+    if [ -s "$_tws_file" ]; then
       printf '\n' >> "$_tws_tmp"
       cat "$_tws_file" >> "$_tws_tmp"
     fi
   fi
 
-  mv "$_tws_tmp" "$_tws_file"
-  rm -f "$_tws_block"
+  _ksm_inplace_from "$_tws_tmp" "$_tws_file" || {
+    rm -f "$_tws_tmp" "$_tws_block"
+    unset _tws_file _tws_block _tws_tmp _tws_pkg
+    return 1
+  }
+  rm -f "$_tws_tmp" "$_tws_block"
   unset _tws_file _tws_block _tws_tmp _tws_pkg
 }
 
-# Sets KEY = VALUE inside the [trust] table of FILE, creating the table (and
-# the file) if needed. VALUE must already be TOML-formatted (quoted string,
-# bare number/bool, etc). Idempotent.
+# VALUE must already be TOML-shaped (quoted string, bare number/bool, …).
 _toml_set_trust_key() {
   _tsk_file="$1" _tsk_key="$2" _tsk_val="$3"
+  [ -f "$_tsk_file" ] || { unset _tsk_file _tsk_key _tsk_val; return 1; }
+
   _tsk_tmp="${_tsk_file}.new.$$"
 
-  if [ -f "$_tsk_file" ] && grep -Eq '^\[trust\]' "$_tsk_file"; then
+  if grep -Eq '^\[trust\]' "$_tsk_file"; then
     awk -v key="$_tsk_key" -v val="$_tsk_val" '
       BEGIN { in_trust = 0; done = 0 }
       /^\[/ {
@@ -329,10 +334,15 @@ _toml_set_trust_key() {
       }
     ' "$_tsk_file" > "$_tsk_tmp"
   else
-    if [ -f "$_tsk_file" ]; then cat "$_tsk_file" > "$_tsk_tmp"; else : > "$_tsk_tmp"; fi
+    cat "$_tsk_file" > "$_tsk_tmp"
     printf '\n[trust]\n%s = %s\n' "$_tsk_key" "$_tsk_val" >> "$_tsk_tmp"
   fi
 
-  mv "$_tsk_tmp" "$_tsk_file"
+  _ksm_inplace_from "$_tsk_tmp" "$_tsk_file" || {
+    rm -f "$_tsk_tmp"
+    unset _tsk_file _tsk_key _tsk_val _tsk_tmp
+    return 1
+  }
+  rm -f "$_tsk_tmp"
   unset _tsk_file _tsk_key _tsk_val _tsk_tmp
 }

--- a/src/uninstall.sh
+++ b/src/uninstall.sh
@@ -5,9 +5,11 @@ MODDIR=${0%/*}
 
 detect_keystore_manager
 if [ -f "$BACKUP_FILE" ] && [ -n "$KSM_KEYBOX" ]; then
-    rm -f "$KSM_KEYBOX"
-    mv "$BACKUP_FILE" "$KSM_KEYBOX" || true
-    log_i "UNINSTALL" "Restored original keybox from backup"
+    if ksm_install_keybox "$BACKUP_FILE" move; then
+      log_i "UNINSTALL" "Restored original keybox from backup"
+    else
+      log_w "UNINSTALL" "Could not restore keybox (dest missing or write failed)"
+    fi
 fi
 
 if [ -d "$CONFIG_DIR" ]; then

--- a/tests/test_keystore.sh
+++ b/tests/test_keystore.sh
@@ -106,6 +106,11 @@ cp "$_toml_file" "${_toml_file}.snapshot"
 printf 'com.new.app\ncom.other.app\n' | _toml_write_scoop "$_toml_file"
 assert_eq "toml write: idempotent (same input -> same output)" "$(cat "${_toml_file}.snapshot")" "$(cat "$_toml_file")"
 
+_inode_before=$(stat -c %i "$_toml_file")
+printf 'com.new.app\ncom.other.app\n' | _toml_write_scoop "$_toml_file"
+_inode_after=$(stat -c %i "$_toml_file")
+assert_eq "toml write: in-place overwrite keeps inode" "$_inode_before" "$_inode_after"
+
 # ---------- _toml_write_scoop: missing scoop key gets injected before first section ----------
 bootstrap
 source_libs
@@ -118,6 +123,14 @@ printf 'pkg.one\n' | _toml_write_scoop "$_noscoop"
 assert_contains "toml write: injects scoop when absent" "$(cat "$_noscoop")" "scoop = ["
 _scoop_injected=$(_toml_read_scoop "$_noscoop")
 assert_eq "toml write: injected value readable" "pkg.one" "$_scoop_injected"
+
+# ---------- _toml_write_scoop: missing file fails closed (no create) ----------
+bootstrap
+source_libs
+_missing_toml="$TEST_ROOT/does-not-exist.toml"
+printf 'pkg.one\n' | _toml_write_scoop "$_missing_toml" 2>/dev/null; _tw_missing_rc=$?
+assert_exit_code "toml write: missing file fails" 1 "$_tw_missing_rc"
+assert_file_not_exists "toml write: missing file not created" "$_missing_toml"
 
 # ---------- _toml_set_trust_key: existing key replaced ----------
 bootstrap
@@ -139,6 +152,11 @@ assert_contains "trust key: other sections preserved" "$(cat "$_cfg_toml")" "[de
 cp "$_cfg_toml" "${_cfg_toml}.snapshot"
 _toml_set_trust_key "$_cfg_toml" security_patch '"2026-06-05"'
 assert_eq "trust key: idempotent" "$(cat "${_cfg_toml}.snapshot")" "$(cat "$_cfg_toml")"
+
+_inode_trust_before=$(stat -c %i "$_cfg_toml")
+_toml_set_trust_key "$_cfg_toml" security_patch '"2026-06-05"'
+_inode_trust_after=$(stat -c %i "$_cfg_toml")
+assert_eq "trust key: in-place overwrite keeps inode" "$_inode_trust_before" "$_inode_trust_after"
 
 # ---------- _toml_set_trust_key: section exists without the key ----------
 bootstrap
@@ -162,6 +180,14 @@ EOF
 _toml_set_trust_key "$_cfg_toml3" security_patch '"2026-06-05"'
 assert_contains "trust key: creates [trust] section" "$(cat "$_cfg_toml3")" "[trust]"
 assert_contains "trust key: value set in new section" "$(cat "$_cfg_toml3")" 'security_patch = "2026-06-05"'
+
+# ---------- _toml_set_trust_key: missing file fails closed (no create) ----------
+bootstrap
+source_libs
+_missing_cfg="$TEST_ROOT/missing-config.toml"
+_toml_set_trust_key "$_missing_cfg" security_patch '"2026-06-05"' 2>/dev/null; _tsk_missing_rc=$?
+assert_exit_code "trust key: missing file fails" 1 "$_tsk_missing_rc"
+assert_file_not_exists "trust key: missing file not created" "$_missing_cfg"
 
 # ---------- ksm_set_security_patch: Tricky Store multi-line (vendor from prop) ----------
 bootstrap
@@ -351,19 +377,62 @@ assert_file_not_exists "targets toml commit: no restart.keymint created" "$OMK_R
 assert_file_not_exists "targets toml commit: no restart.all created" "$OMK_RESTART_DIR/restart.all"
 assert_contains "targets toml commit: other sections preserved" "$(cat "$OMK_INJECTOR")" "[main]"
 
-# ---------- ksm_install_keybox: OMK does not touch restart markers ----------
+# ---------- ksm_install_keybox: OMK in-place overwrite, no restart markers ----------
+bootstrap
+source_libs
+mk_module oh_my_keymint "OhMyKeymint"
+mkdir -p "$OMK_DIR"
+printf '<old/>\n' > "$OMK_KEYBOX"
+detect_keystore_manager
+_kb_src="$TEST_ROOT/src_keybox.xml"
+printf '<AndroidAttestation/>\n' > "$_kb_src"
+_kb_inode_before=$(stat -c %i "$KSM_KEYBOX")
+ksm_install_keybox "$_kb_src" copy
+assert_file_exists "install keybox: keybox installed" "$KSM_KEYBOX"
+assert_contains "install keybox: content overwritten" "$(cat "$KSM_KEYBOX")" "<AndroidAttestation/>"
+assert_file_exists "install keybox: copy preserves src" "$_kb_src"
+assert_eq "install keybox: in-place overwrite keeps inode" "$_kb_inode_before" "$(stat -c %i "$KSM_KEYBOX")"
+assert_file_not_exists "install keybox: no restart.keymint" "$OMK_RESTART_DIR/restart.keymint"
+assert_file_not_exists "install keybox: no restart.injector" "$OMK_RESTART_DIR/restart.injector"
+assert_file_not_exists "install keybox: no restart.all" "$OMK_RESTART_DIR/restart.all"
+
+# ---------- ksm_install_keybox: OMK move consumes src ----------
+bootstrap
+source_libs
+mk_module oh_my_keymint "OhMyKeymint"
+mkdir -p "$OMK_DIR"
+printf '<old/>\n' > "$OMK_KEYBOX"
+detect_keystore_manager
+_kb_move_src="$TEST_ROOT/move_keybox.xml"
+printf '<Moved/>\n' > "$_kb_move_src"
+ksm_install_keybox "$_kb_move_src"
+assert_contains "install keybox move: content written" "$(cat "$KSM_KEYBOX")" "<Moved/>"
+assert_file_not_exists "install keybox move: src consumed" "$_kb_move_src"
+
+# ---------- ksm_install_keybox: OMK missing dest fails closed ----------
 bootstrap
 source_libs
 mk_module oh_my_keymint "OhMyKeymint"
 mkdir -p "$OMK_DIR"
 detect_keystore_manager
-_kb_src="$TEST_ROOT/src_keybox.xml"
-printf '<AndroidAttestation/>\n' > "$_kb_src"
-ksm_install_keybox "$_kb_src" copy
-assert_file_exists "install keybox: keybox installed" "$KSM_KEYBOX"
-assert_file_not_exists "install keybox: no restart.keymint" "$OMK_RESTART_DIR/restart.keymint"
-assert_file_not_exists "install keybox: no restart.injector" "$OMK_RESTART_DIR/restart.injector"
-assert_file_not_exists "install keybox: no restart.all" "$OMK_RESTART_DIR/restart.all"
+_kb_fail_src="$TEST_ROOT/fail_keybox.xml"
+printf '<Nope/>\n' > "$_kb_fail_src"
+ksm_install_keybox "$_kb_fail_src" copy 2>/dev/null; _kb_fail_rc=$?
+assert_exit_code "install keybox: missing dest fails" 1 "$_kb_fail_rc"
+assert_file_not_exists "install keybox: missing dest not created" "$KSM_KEYBOX"
+assert_file_exists "install keybox: src kept on fail" "$_kb_fail_src"
+
+# ---------- ksm_install_keybox: OMK missing dir fails closed (no mkdir) ----------
+bootstrap
+source_libs
+mk_module oh_my_keymint "OhMyKeymint"
+rm -rf "$OMK_DIR"
+detect_keystore_manager
+_kb_nodir_src="$TEST_ROOT/nodir_keybox.xml"
+printf '<Nope/>\n' > "$_kb_nodir_src"
+ksm_install_keybox "$_kb_nodir_src" copy 2>/dev/null; _kb_nodir_rc=$?
+assert_exit_code "install keybox: missing dir fails" 1 "$_kb_nodir_rc"
+assert_file_not_exists "install keybox: missing dir not created" "$OMK_DIR"
 
 # ---------- ksm_reload touches only the keymint restart trigger ----------
 bootstrap
@@ -395,16 +464,6 @@ detect_keystore_manager
 ksm_reload
 assert_file_not_exists "reload: TS creates no restart.keymint" "$OMK_RESTART_DIR/restart.keymint"
 assert_file_not_exists "reload: TS creates no restart.all" "$OMK_RESTART_DIR/restart.all"
-
-# ---------- ksm_secure is a no-op for Tricky Store (files stay untouched) ----------
-bootstrap
-source_libs
-mk_module tricky_store "Tricky Store"
-detect_keystore_manager
-_sec_file="$TEST_ROOT/plain.txt"
-echo hi > "$_sec_file"
-ksm_secure "$_sec_file" 0600
-assert_file_exists "secure: TS leaves file in place" "$_sec_file"
 
 # ---------- omk_restart_keymint.sh: rejects non-OMK managers ----------
 bootstrap


### PR DESCRIPTION
## Summary
- Specter→OMK writes (`injector.toml`, `config.toml`, `keybox.xml`) use in-place overwrite so the existing inode (uid 1017) stays; remove `ksm_secure`.
- Fail closed if the OMK dest file/dir is missing — OMK owns layout create.
- Tricky Store replace behavior is unchanged.

### Restore / uninstall keybox
Those paths were still doing raw `cp` / `rm`+`mv` onto `$KSM_KEYBOX`, which on OMK creates a new root-owned inode and undoes the in-place strategy.

- `restore_backups.sh` — restore keybox via `ksm_install_keybox … copy` (keeps the backup file). On OMK this overwrites the existing dest in place; if the dest is missing, restore fails and logs instead of creating a root-owned keybox. Target list / security patch restore already went through `ksm_*` helpers.
- `uninstall.sh` — stop `rm` then `mv` (that threw away the OMK inode on purpose). Put the backup back with `ksm_install_keybox … move` so OMK keeps the layout inode and the backup is consumed on success.