### PR TITLE
ui: let app targeting list scroll again

### DIFF
--- a/src/webroot/css/app.css
+++ b/src/webroot/css/app.css
@@ -1593,6 +1593,7 @@ md-filled-tonal-button {
   max-width: 800px;
   margin: 0 auto;
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   position: relative;


### PR DESCRIPTION
## Summary
- App Targeting list stopped scrolling after `.ta-inner` was added for the max-width layout
- Add `min-height: 0` so the flex child can shrink and `.ta-list` becomes the scroll container again