### PR TITLE
web: fix terminal copy/clear translations (#66)

### DIFF
--- a/src/webroot/js/i18n.ts
+++ b/src/webroot/js/i18n.ts
@@ -47,7 +47,7 @@ function applyTranslations() {
     const val = currentStrings[key] || fallbackStrings[key];
     if (!val) continue;
     if (el.tagName === 'TITLE') { document.title = val; continue; }
-    if (el.tagName.startsWith('MD-')) {
+    if (el.tagName === 'MD-FILTER-CHIP') {
       (el as HTMLElement & { label: string }).label = val;
       if (el.hasAttribute('aria-label')) el.setAttribute('aria-label', val);
       continue;


### PR DESCRIPTION
## Summary
- Fixes [#66](https://github.com/dpejoh/specter/issues/66): Settings terminal **Copy** / **Clear** always stayed English because `applyTranslations` set `.label` on every `MD-*` element.
- Only `md-filter-chip` uses a real `label` prop; `md-text-button` uses light-DOM text, so those buttons now fall through to `textContent`.