### PR TITLE
web: list bocho8 as webui & backend contributor

### DIFF
--- a/src/webroot/json/dev.json
+++ b/src/webroot/json/dev.json
@@ -23,7 +23,7 @@
   {
     "name": "bocho",
     "username": "bocho8",
-    "role": "WebUI Contributor",
+    "role": "WebUI & Backend Contributor",
     "github": "https://github.com/bocho8",
     "avatar": "https://github.com/bocho8.png"
   },

--- a/src/webroot/lang/ar.json
+++ b/src/webroot/lang/ar.json
@@ -129,6 +129,7 @@
   "role_French Translator": "French Translator",
   "role_Polish Translator": "Polish Translator",
   "role_Backend Contributor": "Backend Contributor",
+  "role_WebUI & Backend Contributor": "WebUI & Backend Contributor",
   "install_now": "تثبيت الآن",
   "custom_kb_title": "Keybox مخصص",
   "custom_kb_file": "استيراد ملف",

--- a/src/webroot/lang/es.json
+++ b/src/webroot/lang/es.json
@@ -129,6 +129,7 @@
   "role_French Translator": "Traductor de francés",
   "role_Polish Translator": "Traductor de polaco",
   "role_Backend Contributor": "Colaborador de Backend",
+  "role_WebUI & Backend Contributor": "Colaborador de WebUI y Backend",
   "install_now": "Instalar ahora",
   "custom_kb_title": "Keybox personalizado",
   "custom_kb_file": "Importar archivo",

--- a/src/webroot/lang/fr.json
+++ b/src/webroot/lang/fr.json
@@ -133,6 +133,7 @@
   "role_French Translator": "Traducteur du français",
   "role_Polish Translator": "Traducteur du polonais",
   "role_Backend Contributor": "Contributeur au Backend",
+  "role_WebUI & Backend Contributor": "Contributeur WebUI et Backend",
   "install_now": "Installer",
   "custom_kb_title": "Keybox personnalisée",
   "custom_kb_file": "Import de fichier",

--- a/src/webroot/lang/id.json
+++ b/src/webroot/lang/id.json
@@ -129,6 +129,7 @@
   "role_French Translator": "Penerjemah bahasa Prancis",
   "role_Polish Translator": "Penerjemah bahasa Polandia",
   "role_Backend Contributor": "Backend Contributor",
+  "role_WebUI & Backend Contributor": "WebUI & Backend Contributor",
   "install_now": "Pasang sekarang",
   "custom_kb_title": "Keybox Kustom",
   "custom_kb_file": "Impor File",

--- a/src/webroot/lang/pl.json
+++ b/src/webroot/lang/pl.json
@@ -129,6 +129,7 @@
   "role_French Translator": "Tłumacz francuski",
   "role_Polish Translator": "Tłumacz polski",
   "role_Backend Contributor": "Współtwórca backendu",
+  "role_WebUI & Backend Contributor": "Współtwórca WebUI i backendu",
   "install_now": "Instaluj teraz",
   "custom_kb_title": "Własny Keybox",
   "custom_kb_file": "Importuj plik",

--- a/src/webroot/lang/ru.json
+++ b/src/webroot/lang/ru.json
@@ -134,6 +134,7 @@
   "role_French Translator": "Французский переводчик",
   "role_Polish Translator": "Польский переводчик",
   "role_Backend Contributor": "Контрибьютор бэкенда",
+  "role_WebUI & Backend Contributor": "Контрибьютор веб-интерфейса и бэкенда",
   "install_now": "Установить сейчас",
   "custom_kb_title": "Пользовательский Keybox",
   "custom_kb_file": "Импорт файла",

--- a/src/webroot/lang/source/string.json
+++ b/src/webroot/lang/source/string.json
@@ -133,6 +133,7 @@
   "role_French Translator": "French Translator",
   "role_Polish Translator": "Polish Translator",
   "role_Backend Contributor": "Backend Contributor",
+  "role_WebUI & Backend Contributor": "WebUI & Backend Contributor",
   "install_now": "Install now",
   "custom_kb_title": "Custom Keybox",
   "custom_kb_file": "Import File",

--- a/src/webroot/lang/tr.json
+++ b/src/webroot/lang/tr.json
@@ -129,6 +129,7 @@
   "role_French Translator": "Fransızca Çevirmeni",
   "role_Polish Translator": "Lehçe Çevirmeni",
   "role_Backend Contributor": "Arkada Katkı Sağlayan",
+  "role_WebUI & Backend Contributor": "Arayüz ve Arkada Katkı Sağlayan",
   "install_now": "Şimdi yükle",
   "custom_kb_title": "Özel Keybox",
   "custom_kb_file": "Dosya seç",

--- a/src/webroot/lang/zh.json
+++ b/src/webroot/lang/zh.json
@@ -129,6 +129,7 @@
   "role_French Translator": "法语翻译",
   "role_Polish Translator": "波兰语翻译",
   "role_Backend Contributor": "Backend Contributor",
+  "role_WebUI & Backend Contributor": "WebUI 与 Backend 贡献者",
   "install_now": "立即安装",
   "custom_kb_title": "自定义 Keybox",
   "custom_kb_file": "导入文件",


### PR DESCRIPTION
## Summary
- Update bocho8's contributor role from `WebUI Contributor` to `WebUI & Backend Contributor` (🥺).
- Add `role_WebUI & Backend Contributor` i18n keys across source and locale files.